### PR TITLE
configure.ac: check for <execinfo.h>

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -75,6 +75,7 @@ AC_CHECK_HEADERS([sched.h sys/dkstat.h sys/param.h sys/sysctl.h uvm/uvm_param.h]
 AC_CHECK_HEADERS([libgen.h])
 AC_CHECK_HEADERS([machine/apmvar.h])
 AC_CHECK_HEADERS([machine/apm_bios.h])
+AC_CHECK_HEADERS([execinfo.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_CHECK_HEADER_STDBOOL

--- a/src/misc.cc
+++ b/src/misc.cc
@@ -15,7 +15,7 @@
 #include <libgen.h>
 #endif
 
-#ifdef linux
+#if defined(linux) && defined(HAVE_EXECINFO_H)
 #include <execinfo.h>
 #endif
 
@@ -543,7 +543,7 @@ bool isreg(char const *path) {
 }
 
 void show_backtrace() {
-#ifdef linux
+#if defined(linux) && defined(HAVE_EXECINFO_H)
     void *array[20];
 
     fprintf(stderr, "\nbacktrace:\n");


### PR DESCRIPTION
Some C standard libraries either don't provide backtrace, or
provide it conditionally as is the case with uClibc.  We add
a check in configure.ac to see if execinfo.h exists, and if it
does not, then we disable show_backtrace() in src/misc.cc.

Signed-off-by: Anthony G. Basile blueness@gentoo.org
