### PR TITLE
Add preference to allow disabling "smart" window rearranging when screen size changes

### DIFF
--- a/src/default.h
+++ b/src/default.h
@@ -114,6 +114,7 @@ XIV(bool, centerMaximizedWindows,               false)
 XIV(bool, hideBordersMaximized,                 false)
 XIV(bool, win95keys,                            true)
 XIV(bool, autoReloadMenus,                      true)
+XIV(bool, arrangeWindowsOnScreenSizeChange,     true)
 XIV(bool, clientMouseActions,                   true)
 XIV(bool, showPrograms,                         false)
 XIV(bool, showSettingsMenu,                     true)
@@ -279,6 +280,7 @@ cfoption icewm_preferences[] = {
     OBV("VerticalEdgeSwitch",                   &edgeVertWorkspaceSwitching,    "Workspace switches by moving mouse to top/bottom screen edge"),
     OBV("ContinuousEdgeSwitch",                 &edgeContWorkspaceSwitching,    "Workspace switches continuously when moving mouse to screen edge"),
     OBV("AutoReloadMenus",                      &autoReloadMenus,               "Reload menu files automatically"),
+    OBV("ArrangeWindowsOnScreenSizeChange",     &arrangeWindowsOnScreenSizeChange, "Automatically arrange windows when screen size changes"),
 #ifdef CONFIG_TASKBAR
     OBV("ShowTaskBar",                          &showTaskBar,                   "Show task bar"),
     OBV("TaskBarAtTop",                         &taskBarAtTop,                  "Task bar at top of the screen"),

--- a/src/wmmgr.cc
+++ b/src/wmmgr.cc
@@ -3468,7 +3468,9 @@ void YWindowManager::UpdateScreenSize(XEvent *event) {
         }
 
 /// TODO #warning "make something better"
-        wmActionListener->actionPerformed(actionArrange, 0);
+        if (arrangeWindowsOnScreenSizeChange) {
+            wmActionListener->actionPerformed(actionArrange, 0);
+        }
     }
 }
 #endif


### PR DESCRIPTION
New preference "ArrangeWindowsOnScreenSizeChange": Automatically arrange windows when screen size changes.

Defaults to current behavior, allowing one to disable it.

This has annoyed me for as long as it has existed. I finally decided to allow myself to get rid of it.

I don't know if it makes sense to do pull requests here. I'm not willing to go to sourceforge anyway though, so might as well put this here.
