### PR TITLE
Add memory status monitor applet.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -326,6 +326,7 @@ if test x$enable_lite != xyes ; then
 	AC_DEFINE([CONFIG_TRAY],[1],[Define for system tray.])
 	AC_DEFINE([CONFIG_APPLET_MAILBOX],[1],[Define for mailbox applet.])
 	AC_DEFINE([CONFIG_APPLET_CPU_STATUS],[1],[Define for CPU status applet.])
+	AC_DEFINE([CONFIG_APPLET_MEM_STATUS],[1],[Define for memory status applet.])
 	AC_DEFINE([CONFIG_APPLET_NET_STATUS],[1],[Define for network status applet.])
 	AC_DEFINE([CONFIG_APPLET_CLOCK],[1],[Define for LCD clock applet.])
 	AC_DEFINE([CONFIG_APPLET_APM],[1],[Define for APM status applet.])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -286,6 +286,8 @@ icewm_SOURCES = \
 	aclock.h \
 	acpustatus.cc \
 	acpustatus.h \
+	amemstatus.cc \
+	amemstatus.h \
 	apppstatus.cc \
 	apppstatus.h \
 	aaddressbar.cc \
@@ -452,6 +454,8 @@ icebar_SOURCES = \
 	aclock.h \
 	acpustatus.cc \
 	acpustatus.h \
+	amemstatus.cc \
+	amemstatus.h \
 	apppstatus.cc \
 	apppstatus.h \
 	aaddressbar.cc \

--- a/src/amemstatus.cc
+++ b/src/amemstatus.cc
@@ -1,0 +1,260 @@
+/*
+ * IceWM
+ *
+ * Copyright (C) 1998-2015 Marko Macek, Matthew Ogilvie
+ *
+ * Memory Status
+ */
+#include "config.h"
+
+#ifdef CONFIG_APPLET_MEM_STATUS
+#include "ylib.h"
+#include "wmapp.h"
+
+#include "amemstatus.h"
+#include "sysdep.h"
+#include "default.h"
+
+#include "ytimer.h"
+
+#include "intl.h"
+
+#if defined(linux)
+
+#define USE_PROC_MEMINFO
+
+extern ref<YPixmap> taskbackPixmap;
+
+MEMStatus::MEMStatus(YWindow *aParent): YWindow(aParent) {
+    samples = new unsigned long long *[taskBarMEMSamples];
+
+    for (int a(0); a < taskBarMEMSamples; a++)
+        samples[a] = new unsigned long long[MEM_STATES];
+
+    fUpdateTimer = new YTimer(taskBarMEMDelay);
+    if (fUpdateTimer) {
+        fUpdateTimer->setTimerListener(this);
+        fUpdateTimer->startTimer();
+    }
+
+    for (int j(0); j < MEM_STATES; j++)
+    {
+        color[j] = NULL;
+    }
+    color[MEM_USER] = new YColor(clrMemUser);
+    color[MEM_BUFFERS] = new YColor(clrMemBuffers);
+    color[MEM_CACHED] = new YColor(clrMemCached);
+    if (*clrMemFree) {
+        color[MEM_FREE] = new YColor(clrMemFree);
+    }
+    for (int i = 0; i < taskBarMEMSamples; i++) {
+        for (int j=0; j < MEM_STATES; j++)
+            samples[i][j]=0;
+        samples[i][MEM_FREE] = 1;
+    }
+    setSize(taskBarMEMSamples, 20);
+    getStatus();
+    updateStatus();
+    updateToolTip();
+}
+
+MEMStatus::~MEMStatus() {
+    delete fUpdateTimer;
+    for (int a(0); a < taskBarMEMSamples; a++) {
+        delete samples[a]; samples[a] = 0;
+    }
+    delete samples; samples = 0;
+    for (int j(0); j < MEM_STATES; j++) {
+        delete color[j]; color[j] = 0;
+    }
+}
+
+void MEMStatus::paint(Graphics &g, const YRect &/*r*/) {
+    int h = height();
+
+    for (int i(0); i < taskBarMEMSamples; i++) {
+        unsigned long long total = 0;
+        int j;
+        for (j = 0; j < MEM_STATES; j++) {
+            total += samples[i][j];
+        }
+
+        int y = h;
+        for (j = 0; j < MEM_STATES; j++) {
+            int bar;
+            if (j == MEM_STATES-1) {
+                bar = y;
+            } else {
+                bar = (int)((h * samples[i][j]) / total);
+            }
+
+            if (bar <= 0) {
+                continue;
+            }
+
+            if(color[j]) {
+                g.setColor(color[j]);
+                g.drawLine(i, y-1, i, y-bar);
+            } else {
+#ifdef CONFIG_GRADIENTS
+                ref<YImage> gradient = parent()->getGradient();
+
+                if (gradient != null)
+                    g.drawImage(gradient,
+                                this->x() + i, this->y() + y - bar,
+                                width(), bar,
+                                i, y - bar);
+                else
+#endif
+                    if (taskbackPixmap != null)
+                        g.fillPixmap(taskbackPixmap,
+                                     i, y - bar,
+                                     width(), bar,
+                                     this->x() + i, this->y() + y - bar);
+            }
+            y -= bar;
+        }
+    }
+}
+
+bool MEMStatus::handleTimer(YTimer *t) {
+    if (t != fUpdateTimer)
+        return false;
+    updateStatus();
+    if (toolTipVisible())
+        updateToolTip();
+    return true;
+}
+
+void MEMStatus::printAmount(char *out, size_t outSize,
+                            unsigned long long amount) {
+    if(amount >= (200ull*1024*1024*1024)) {
+        snprintf( out, outSize, "%llu %.20s",
+                  amount/(1024*1024*1024),
+                  _("GB") );
+    } else if(amount >= (200*1024*1024)) {
+        snprintf( out, outSize, "%llu %.20s",
+                  amount/(1024*1024),
+                  _("MB") );
+    } else if(amount >= (200*1024)) {
+        snprintf( out, outSize, "%llu %.20s",
+                  amount/1024,
+                  _("kB") );
+    } else {
+        snprintf( out, outSize, "%llu %.20s",
+                  amount,
+                  _("bytes") );
+    }
+    out[outSize-1]='\0';
+}
+
+void MEMStatus::updateToolTip() {
+    unsigned long long *cur=samples[taskBarMEMSamples-1];
+
+    unsigned long long total = 0;
+    for (int j(0); j < MEM_STATES; j++) {
+        total += cur[j];
+    }
+
+    char totalStr[64];
+    printAmount(totalStr, sizeof(totalStr), total);
+    char freeStr[64];
+    printAmount(freeStr, sizeof(freeStr), cur[MEM_FREE]);
+    char userStr[64];
+    printAmount(userStr, sizeof(userStr), cur[MEM_USER]);
+    char buffersStr[64];
+    printAmount(buffersStr, sizeof(buffersStr), cur[MEM_BUFFERS]);
+    char cachedStr[64];
+    printAmount(cachedStr, sizeof(cachedStr), cur[MEM_CACHED]);
+
+    char *memmsg = cstrJoin(_("Memory Total: "), totalStr, "\n   ",
+                            _("Free: "), freeStr, "\n   ",
+                            _("Cached: "), cachedStr, "\n   ",
+                            _("Buffers: "), buffersStr, "\n   ",
+                            _("User: "), userStr,
+                            NULL );
+    setToolTip(memmsg);
+    delete [] memmsg;
+}
+
+void MEMStatus::updateStatus() {
+    for (int i(1); i < taskBarMEMSamples; i++) {
+        for (int j(0); j < MEM_STATES ; j++) {
+            samples[i-1][j] = samples[i][j];
+        }
+    }
+    getStatus(),
+    repaint();
+}
+
+unsigned long long MEMStatus::parseField(const char *buf, size_t bufLen,
+                                         const char *needle) {
+#ifdef USE_PROC_MEMINFO
+    ptrdiff_t needleLen = strlen(needle);
+    const char *end = buf + bufLen;
+    while(buf < end) {
+        const char *nl = (const char *)memchr(buf, '\n', end-buf);
+        if(nl == 0)
+            break;
+
+        if(nl-buf > needleLen && memcmp(buf, needle, needleLen) == 0) {
+            char *endptr = NULL;
+            unsigned long long result = strtoull(buf+needleLen, &endptr, 10);
+
+            while(endptr!=0 && *endptr==' ')
+                endptr++;
+
+            if(*endptr=='k') {   // normal case
+                result *= 1024;
+            } else if(*endptr=='M') {
+                result *= 1024*1024;
+            } else if(*endptr=='G') {
+                result *= 1024*1024*1024;
+            }
+            return result;
+        }
+
+        buf = nl+1;
+    }
+#endif /*USE_PROC_MEMINFO*/
+    return 0;
+}
+
+void MEMStatus::getStatus() {
+    unsigned long long *cur=samples[taskBarMEMSamples-1];
+    int j;
+    for (j = 0; j < MEM_STATES; j++) {
+        cur[j] = 0;
+    }
+    cur[MEM_FREE] = 1;
+
+#ifdef USE_PROC_MEMINFO
+    int fd = open("/proc/meminfo", O_RDONLY);
+    if (fd == -1)
+        return;
+
+    char buf[4096];
+    ssize_t len = read(fd, buf, sizeof(buf)-1);
+    close(fd);
+    if (len < 0) {
+        return;
+    }
+    buf[len] = '\0';
+
+    cur[MEM_BUFFERS] = parseField(buf, len, "Buffers:");
+    cur[MEM_CACHED] = parseField(buf, len, "Cached:");
+    cur[MEM_FREE] = parseField(buf, len, "MemFree:");
+
+    unsigned long long total = parseField(buf, len, "MemTotal:");
+    if (total < 1)
+        total = 1;
+
+    unsigned long long user = total;
+    for (j = 0; j < MEM_STATES; j++) {
+        user -= cur[j];
+    }
+    cur[MEM_USER] = user;
+#endif // USE_PROC_MEMINFO
+}
+#endif
+#endif

--- a/src/amemstatus.h
+++ b/src/amemstatus.h
@@ -1,0 +1,43 @@
+#ifndef __MEMSTATUS_H
+#define __MEMSTATUS_H
+
+#if defined(linux)
+
+// graphed from the bottom up:
+#define MEM_USER    (0)
+#define MEM_BUFFERS (1)
+#define MEM_CACHED  (2)
+#define MEM_FREE    (3)
+#define MEM_STATES  (4)
+
+#include "ywindow.h"
+
+class MEMStatus: public YWindow, public YTimerListener {
+public:
+    MEMStatus(YWindow *aParent = 0);
+    virtual ~MEMStatus();
+
+    virtual void paint(Graphics &g, const YRect &r);
+
+    virtual bool handleTimer(YTimer *t);
+
+    void updateStatus();
+    void getStatus();
+    void updateToolTip();
+
+private:
+    static void printAmount(char *out, size_t outSize,
+                            unsigned long long amount);
+    static unsigned long long parseField(const char *buf,
+                                         size_t bufLen,
+                                         const char *needle);
+
+    unsigned long long int **samples;
+    YColor *color[MEM_STATES];
+    YTimer *fUpdateTimer;
+};
+#else
+#undef CONFIG_APPLET_MEM_STATUS
+#endif
+
+#endif

--- a/src/default.h
+++ b/src/default.h
@@ -70,6 +70,7 @@ XIV(bool, cpustatusShowRamUsage,                true)
 XIV(bool, cpustatusShowSwapUsage,               true)
 XIV(bool, cpustatusShowAcpiTemp,                true)
 XIV(bool, cpustatusShowCpuFreq,                 true)
+XIV(bool, taskBarShowMEMStatus,                 false)
 XIV(bool, taskBarShowNetStatus,                 true)
 XIV(bool, taskBarLaunchOnSingleClick,           true)
 XIV(bool, taskBarShowCollapseButton,            false)
@@ -157,6 +158,7 @@ XIV(int, msgBoxDefaultAction,                   0)
 XIV(int, mailCheckDelay,                        30)
 XIV(int, taskBarCPUSamples,                     20)
 XIV(int, taskBarApmGraphWidth,                  10) // hatred
+XIV(int, taskBarMEMSamples,                     20)
 XIV(int, focusRequestFlashTime,                 0)
 XIV(int, focusRequestFlashInterval,             250)
 XIV(int, nestedThemeMenuMinNumber,              15)
@@ -187,6 +189,7 @@ XSV(const char *, shutdownCommand,              0)
 XSV(const char *, rebootCommand,                0)
 #endif // LINUX
 XIV(int, taskBarCPUDelay,                       500)
+XIV(int, taskBarMEMDelay,                       500)
 XIV(int, taskBarNetSamples,                     20)
 XIV(int, taskBarNetDelay,                       500)
 XSV(const char *, cpuCommand,                   "xterm -name top -title Process\\ Status -e top")
@@ -312,6 +315,7 @@ cfoption icewm_preferences[] = {
     OBV("CPUStatusShowSwapUsage",               &cpustatusShowSwapUsage,        "Show swap usage in CPU status tool tip"),
     OBV("CPUStatusShowAcpiTemp",                &cpustatusShowAcpiTemp,         "Show ACPI temperature in CPU status tool tip"),
     OBV("CPUStatusShowCpuFreq",                 &cpustatusShowCpuFreq,          "Show CPU frequency in CPU status tool tip"),
+    OBV("TaskBarShowMEMStatus",                 &taskBarShowMEMStatus,          "Show memory usage status on task bar (Linux only)"),
     OBV("TaskBarShowNetStatus",                 &taskBarShowNetStatus,          "Show network status on task bar (Linux only)"),
     OBV("TaskBarShowCollapseButton",            &taskBarShowCollapseButton,     "Show a button to collapse the taskbar"),
     OBV("TaskBarDoubleHeight",                  &taskBarDoubleHeight,           "Use double-height task bar"),
@@ -382,8 +386,10 @@ cfoption icewm_preferences[] = {
     OIV("MsgBoxDefaultAction",                  &msgBoxDefaultAction, 0, 1,     "Preselect to Cancel (0) or the OK (1) button in message boxes"),
     OIV("MailCheckDelay",                       &mailCheckDelay, 0, (3600*24),  "Delay between new-mail checks. (seconds)"),
 #ifdef CONFIG_TASKBAR
-    OIV("TaskBarCPUSamples",                    &taskBarCPUSamples, 2, 1000,    "Width of CPU Monitor"),
     OIV("TaskBarCPUDelay",                      &taskBarCPUDelay, 10, (60*60*1000),    "Delay between CPU Monitor samples in ms"),
+    OIV("TaskBarCPUSamples",                    &taskBarCPUSamples, 2, 1000,    "Width of CPU Monitor"),
+    OIV("TaskBarMEMSamples",                    &taskBarMEMSamples, 2, 1000,    "Width of Memory Monitor"),
+    OIV("TaskBarMEMDelay",                      &taskBarMEMDelay, 10, (60*60*1000),    "Delay between Memory Monitor samples in ms"),
     OIV("TaskBarNetSamples",                    &taskBarNetSamples, 2, 1000,    "Width of Net Monitor"),
     OIV("TaskBarNetDelay",                      &taskBarNetDelay, 10, (60*60*1000),    "Delay between Net Monitor samples in ms"),
     OIV("TaskbarButtonWidthDivisor",            &taskBarButtonWidthDivisor, 1, 25, "default number of tasks in taskbar"),

--- a/src/themable.h
+++ b/src/themable.h
@@ -143,6 +143,10 @@ XSV(const char *, clrCpuIoWait,                 "rgb:60/00/60")
 XSV(const char *, clrCpuSoftIrq,                "rgb:00/FF/FF")
 XSV(const char *, clrCpuNice,                   "rgb:00/00/FF")
 XSV(const char *, clrCpuIdle,                   "rgb:00/00/00")
+XSV(const char *, clrMemUser,                   "rgb:40/40/80")
+XSV(const char *, clrMemBuffers,                "rgb:60/60/C0")
+XSV(const char *, clrMemCached,                 "rgb:80/80/FF")
+XSV(const char *, clrMemFree,                   "rgb:00/00/00")
 XSV(const char *, clrNetSend,                   "rgb:FF/FF/00")
 XSV(const char *, clrNetReceive,                "rgb:FF/00/FF")
 XSV(const char *, clrNetIdle,                   "rgb:00/00/00")
@@ -315,6 +319,12 @@ cfoption icewm_themable_preferences[] = {
     OSV("ColorCPUStatusSoftIrq",                &clrCpuSoftIrq,                 "Soft Interrupts on the CPU monitor"),
     OSV("ColorCPUStatusNice",                   &clrCpuNice,                    "Nice load on the CPU monitor"),
     OSV("ColorCPUStatusIdle",                   &clrCpuIdle,                    "Idle (non) load on the CPU monitor, leave empty to force transparency"),
+#endif
+#ifdef CONFIG_APPLET_MEM_STATUS
+    OSV("ColorMEMStatusUser",                   &clrMemUser,                    "User program usage in the memory monitor"),
+    OSV("ColorMEMStatusBuffers",                &clrMemBuffers,                 "OS buffers usage in the memory monitor"),
+    OSV("ColorMEMStatusCached",                 &clrMemCached,                  "OS cached usage in the memory monitor"),
+    OSV("ColorMEMStatusFree",                   &clrMemFree,                    "Free memory in the memory monitor"),
 #endif
 #ifdef CONFIG_APPLET_NET_STATUS
     OSV("ColorNetSend",                         &clrNetSend,                    "Outgoing load on the network monitor"),

--- a/src/wmtaskbar.cc
+++ b/src/wmtaskbar.cc
@@ -28,6 +28,7 @@
 #include "aaddressbar.h"
 #include "aclock.h"
 #include "acpustatus.h"
+#include "amemstatus.h"
 #include "apppstatus.h"
 #include "amailbox.h"
 #include "objbar.h"
@@ -439,6 +440,12 @@ void TaskBar::initMenu() {
 }
 
 void TaskBar::initApplets() {
+#ifdef CONFIG_APPLET_MEM_STATUS
+    if (taskBarShowMEMStatus)
+        fMEMStatus = new MEMStatus(this);
+    else
+        fMEMStatus = 0;
+#endif
 #ifdef CONFIG_APPLET_CPU_STATUS
     if (taskBarShowCPUStatus)
         fCPUStatus = new CPUStatus(smActionListener, this, cpustatusShowRamUsage, cpustatusShowSwapUsage,
@@ -634,6 +641,9 @@ void TaskBar::updateLayout(int &size_w, int &size_h) {
 #endif
 #ifdef CONFIG_APPLET_CPU_STATUS
         { fCPUStatus, false, 1, true, 2, 2, false },
+#endif
+#ifdef CONFIG_APPLET_MEM_STATUS
+        { fMEMStatus, false, 1, true, 2, 2, false },
 #endif
 #ifdef CONFIG_APPLET_NET_STATUS
 #ifdef CONFIG_APPLET_MAILBOX

--- a/src/wmtaskbar.h
+++ b/src/wmtaskbar.h
@@ -9,6 +9,9 @@
 #include "yxtray.h"
 
 class ObjectBar;
+#ifdef CONFIG_APPLET_MEM_STATUS
+class MEMStatus;
+#endif
 #ifdef CONFIG_APPLET_CPU_STATUS
 class CPUStatus;
 #endif
@@ -149,6 +152,9 @@ private:
 #endif
 #ifdef CONFIG_APPLET_MAILBOX
     MailBoxStatus **fMailBoxStatus;
+#endif
+#ifdef CONFIG_APPLET_MEM_STATUS
+    MEMStatus *fMEMStatus;
 #endif
 #ifdef CONFIG_APPLET_CPU_STATUS
     CPUStatus *fCPUStatus;


### PR DESCRIPTION
Add memory applet, similar to the Marko Macet's CPU monitor applet.

I'm not sure what people think about adding new features, but this seems like the
only feature icewm is missing from my perspective.

Works by parsing /proc/meminfo.  Other methods (like the sysinfo()
system call) are missing things.

Question: Would it be better for the default configuration to
show the  applet (in default.h) to make the feature more obvious when
upgrading?  Or is it better to preserve functionality as I have it now?
