### PR TITLE
suppress cmake dev warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 2.6)
+IF (POLICY CMP0053) # in CMake 3.1.0+
+  CMAKE_POLICY (SET CMP0053 OLD) # keep old-style @VAR@ expansion
+ENDIF (POLICY CMP0053)
 PROJECT(ICEWM CXX C)
 
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
CMake Warning (dev) at /usr/share/cmake-3.2/Modules/Compiler/IBMCPP-CXX-DetermineVersionInternal.cmake:2 (set):
  Policy CMP0053 is not set: Simplify variable reference and escape sequence
  evaluation.  Run "cmake --help-policy CMP0053" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  For input:

```
'
  /* __IBMCPP__ = VRP */
# define @PREFIX@COMPILER_VERSION_MAJOR @MACRO_DEC@(__IBMCPP__/100)
# define @PREFIX@COMPILER_VERSION_MINOR @MACRO_DEC@(__IBMCPP__/10 % 10)
# define @PREFIX@COMPILER_VERSION_PATCH @MACRO_DEC@(__IBMCPP__    % 10)'
```

  the old evaluation rules produce:

```
'
  /* __IBMCPP__ = VRP */
# define /usrCOMPILER_VERSION_MAJOR @MACRO_DEC@(__IBMCPP__/100)
# define /usrCOMPILER_VERSION_MINOR @MACRO_DEC@(__IBMCPP__/10 % 10)
# define /usrCOMPILER_VERSION_PATCH @MACRO_DEC@(__IBMCPP__    % 10)'
```

  but the new evaluation rules produce:

```
'
  /* __IBMCPP__ = VRP */
# define @PREFIX@COMPILER_VERSION_MAJOR @MACRO_DEC@(__IBMCPP__/100)
# define @PREFIX@COMPILER_VERSION_MINOR @MACRO_DEC@(__IBMCPP__/10 % 10)
# define @PREFIX@COMPILER_VERSION_PATCH @MACRO_DEC@(__IBMCPP__    % 10)'
```

  Using the old result for compatibility since the policy is not set.
Call Stack (most recent call first):
  /usr/share/cmake-3.2/Modules/Compiler/XL-CXX-DetermineCompiler.cmake:4 (include)
  /usr/share/cmake-3.2/Modules/CMakeCompilerIdDetection.cmake:16 (include)
  /usr/share/cmake-3.2/Modules/CMakeCompilerIdDetection.cmake:44 (_readFile)
  /usr/share/cmake-3.2/Modules/CMakeDetermineCompilerId.cmake:108 (compiler_id_detection)
  /usr/share/cmake-3.2/Modules/CMakeDetermineCompilerId.cmake:126 (CMAKE_DETERMINE_COMPILER_ID_WRITE)
  /usr/share/cmake-3.2/Modules/CMakeDetermineCompilerId.cmake:39 (CMAKE_DETERMINE_COMPILER_ID_BUILD)
  /usr/share/cmake-3.2/Modules/CMakeDetermineCXXCompiler.cmake:103 (CMAKE_DETERMINE_COMPILER_ID)
  CMakeLists.txt:2 (PROJECT)
