### PR TITLE
Fix GetFullWindowProperty for huge icons on 64bit (e.g. Firefox)

### DIFF
--- a/src/wmclient.cc
+++ b/src/wmclient.cc
@@ -1206,7 +1206,7 @@ static void *GetFullWindowProperty(Display *display, Window handle, Atom propAto
         unsigned char *prop;
 
         while (XGetWindowProperty(display, handle,
-                               propAtom, (itemCount * itemSize) / 32, 1024*32, False, AnyPropertyType,
+                               propAtom, (itemCount * itemSize1) / 32, 1024*32, False, AnyPropertyType,
                                &r_type, &r_format, &nitems, &bytes_remain,
                                &prop) == Success && prop)
         {


### PR DESCRIPTION
The long_offset parameter of XGetWindowProperty is always in
32-bit quantities, no matter what sizeof(long) is.

Previously the second read would start too far ahead and result in
a mess for icons which are too large for a single read.

This was reproduced using commit ac6e40a1 on Arch Linux. Start 
Firefox and look at the window icon. xprop says Firefox has 32x32,
64x64, 128x128, and 192x192 icons in NET_WM_ICON which 
would explain why it required another call to XGetWindowProperty.  
