### PR TITLE
Two small fixes from openSUSE

### DIFF
--- a/lib/toolbar.in
+++ b/lib/toolbar.in
@@ -4,6 +4,6 @@
 # since modifications to this file will be discarded when you
 # (re)install icewm.
 #
-prog xterm /usr/share/icons/gnome/16x16/apps/terminal.png xterm
-prog "Web browser" /usr/share/icons/gnome/16x16/apps/web-browser.png xdg-open about:blank
+prog xterm utilities-terminal xterm
+prog "Web browser" web-browser xdg-open about:blank
 

--- a/src/fdomenu.cc
+++ b/src/fdomenu.cc
@@ -378,7 +378,9 @@ int main(int argc, const char **argv)
 		opt_g_free(pmdir);
 	}
 	// user's stuff might replace the system links
-	proc_dir(usershare);
+	gchar *usershare_full = g_strjoin(NULL, usershare, "/applications", NULL);
+	proc_dir(usershare_full);
+	opt_g_free(usershare_full);
 
 	dump_menu();
 


### PR DESCRIPTION
After update to 1.3.11 we needed two small fixes as here, one fixes icons to use anything thats on system and the other one fixes the fdo menu generator not to hang on large /usr contents.

Bit unrelated is that now we have mate patchset which I am not sure would be acceptable:

https://build.opensuse.org/package/view_file/X11:windowmanagers/icewm/icewm-mate.patch?expand=1

So if you want it feel free to take it :)
