### PR TITLE
Enable variable taskbar width

### DIFF
--- a/src/default.h
+++ b/src/default.h
@@ -50,6 +50,8 @@ XIV(bool, taskBarShowWindows,                   true)
 XIV(bool, taskBarShowShowDesktopButton,         true)
 
 XIV(int, taskBarButtonWidthDivisor,             3)
+XIV(int, taskBarWidthPercentage,                100)
+XSV(const char *, taskBarJustify,               "left")
 #ifdef CONFIG_TRAY
 XIV(bool, taskBarShowTray,                      true)
 XIV(bool, trayShowAllWindows,                   true)
@@ -395,6 +397,8 @@ cfoption icewm_preferences[] = {
     OIV("TaskBarNetSamples",                    &taskBarNetSamples, 2, 1000,    "Width of Net Monitor"),
     OIV("TaskBarNetDelay",                      &taskBarNetDelay, 10, (60*60*1000),    "Delay between Net Monitor samples in ms"),
     OIV("TaskbarButtonWidthDivisor",            &taskBarButtonWidthDivisor, 1, 25, "default number of tasks in taskbar"),
+    OIV("TaskBarWidthPercentage",               &taskBarWidthPercentage, 0, 100, "Task bar width as percentage of the screen width"),
+    OSV("TaskBarJustify",                       &taskBarJustify, "Taskbar justify left, right or center"),
     OIV("TaskBarApmGraphWidth",                 &taskBarApmGraphWidth, 1, 1000,  "Width of APM Monitor"), // hatred
 #endif
 

--- a/src/wmtaskbar.cc
+++ b/src/wmtaskbar.cc
@@ -704,7 +704,7 @@ void TaskBar::updateLayout(int &size_w, int &size_h) {
     {
         int dx, dy, dw, dh;
         manager->getScreenGeometry(&dx, &dy, &dw, &dh);
-        w = dw;
+        w = (dw/100.0) * taskBarWidthPercentage;
     }
 
     if (taskBarAtTop) { // !!! for now
@@ -829,6 +829,10 @@ void TaskBar::updateLocation() {
     int w = 0;
     int h = 0;
 
+    w = (dw/100.0) * taskBarWidthPercentage;
+    if (strcmp(taskBarJustify, "right") == 0) x = dw - w;
+    if (strcmp(taskBarJustify, "center") == 0) x = (dw - w)/2;
+    
     updateLayout(w, h);
 
     if (fIsCollapsed) {


### PR DESCRIPTION
This small patch adds an eyecandy like feature, the possibility to set a custom taskbar width. Instead of 100%, a user can configure a percentage between 1 and 100% and set the taskbar to align left, center or right.
