### PR TITLE
Add taskBarWorkspacesTop option.

### DIFF
--- a/src/default.h
+++ b/src/default.h
@@ -61,6 +61,7 @@ XIV(bool, taskBarAutoHide,                      false)
 XIV(bool, taskBarFullscreenAutoShow,            true)
 XIV(bool, taskBarDoubleHeight,                  false)
 XIV(bool, taskBarWorkspacesLeft,                true)
+XIV(bool, taskBarWorkspacesTop,                 false)
 XIV(bool, pagerShowPreview,                     false)
 XIV(bool, pagerShowWindowIcons,                 true)
 XIV(bool, pagerShowMinimized,                   true)
@@ -322,6 +323,7 @@ cfoption icewm_preferences[] = {
     OBV("TaskBarShowCollapseButton",            &taskBarShowCollapseButton,     "Show a button to collapse the taskbar"),
     OBV("TaskBarDoubleHeight",                  &taskBarDoubleHeight,           "Use double-height task bar"),
     OBV("TaskBarWorkspacesLeft",                &taskBarWorkspacesLeft,         "Place workspace pager on left, not right"),
+    OBV("TaskBarWorkspacesTop",                 &taskBarWorkspacesTop,          "Place workspace pager on top row when using dual-height taskbar"),
     OBV("PagerShowPreview",                     &pagerShowPreview,              "Show a mini desktop preview on each workspace button"),
     OBV("PagerShowWindowIcons",                 &pagerShowWindowIcons,          "Draw window icons inside large enough preview windows on pager (if PagerShowPreview=1)"),
     OBV("PagerShowMinimized",                   &pagerShowMinimized,            "Draw even minimized windows as unfilled rectangles (if PagerShowPreview=1)"),

--- a/src/wmtaskbar.cc
+++ b/src/wmtaskbar.cc
@@ -635,7 +635,7 @@ void TaskBar::updateLayout(int &size_w, int &size_h) {
 #ifndef NO_CONFIGURE_MENUS
         { fObjectBar, true, 1, true, 4, 0, true },
 #endif
-        { fWorkspaces, taskBarWorkspacesLeft, 0, true, 4, 4, true },
+        { fWorkspaces, taskBarWorkspacesLeft, taskBarDoubleHeight && taskBarWorkspacesTop, true, 4, 4, true },
 
         { fCollapseButton, false, 0, true, 0, 2, true },
 #ifdef CONFIG_APPLET_CLOCK


### PR DESCRIPTION
This option allows moving the workspace selector to the top row when
using double height taskbar, thus leaving more space for the window
list on the bottom row.
