### PR TITLE
Add option to display ACPI Temperature in CPU Status Bar

### DIFF
--- a/doc/icewm.sgml
+++ b/doc/icewm.sgml
@@ -453,6 +453,7 @@ The following settings can be set to value 1 (enabled) or value 0 (disabled).
 <tag/CPUStatusShowRamUsage = 1/ Show RAM usage in CPU status tool tip.
 <tag/CPUStatusShowSwapUsage = 1/ Show swap usage in CPU status tool tip.
 <tag/CPUStatusShowAcpiTemp = 1/ Show ACPI temperature in CPU status tool tip.
+<tag/CPUStatusShowAcpiTempInGraph = 0/ Show ACPI temperature in CPU graph.
 <tag/CPUStatusShowCpuFreq = 1/ Show CPU frequency in CPU status tool tip.
 <tag/TimeFormat/ format for the taskbar clock (time) (see strftime(3) manpage)
 <tag/DateFormat/ format for the taskbar clock tooltip (date+time) (see strftime(3) manpage).

--- a/src/acpustatus.cc
+++ b/src/acpustatus.cc
@@ -68,7 +68,8 @@ CPUStatus::CPUStatus(
     bool cpustatusShowRamUsage,
     bool cpustatusShowSwapUsage,
     bool cpustatusShowAcpiTemp,
-    bool cpustatusShowCpuFreq): YWindow(aParent),
+    bool cpustatusShowCpuFreq,
+    bool cpustatusShowAcpiTempInGraph): YWindow(aParent),
     		m_nCachedFd(-1)
 {
     this->smActionListener = smActionListener;
@@ -110,6 +111,7 @@ CPUStatus::CPUStatus(
     ShowSwapUsage = cpustatusShowSwapUsage;
     ShowAcpiTemp = cpustatusShowAcpiTemp;
     ShowCpuFreq = cpustatusShowCpuFreq;
+    ShowAcpiTempInGraph = cpustatusShowAcpiTempInGraph;
     getStatus();
     updateStatus();
     updateToolTip();
@@ -216,15 +218,16 @@ void CPUStatus::paint(Graphics &g, const YRect &/*r*/) {
         }
     }
 
-    char test[10];
-    getAcpiTemp(test, sizeof(test));
-    g.setColor(tempColor);
-    g.setFont(tempFont);
-    int y =  (h - 1 - tempFont->height()) / 2 + tempFont->ascent();
-    // If we draw three characters we can get temperatures above 100
-    // without including the "C".
-    g.drawChars(test, 0, 3, 2, y);
-
+    if (ShowAcpiTempInGraph) {
+        char test[10];
+        getAcpiTemp(test, sizeof(test));
+        g.setColor(tempColor);
+        g.setFont(tempFont);
+        int y =  (h - 1 - tempFont->height()) / 2 + tempFont->ascent();
+        // If we draw three characters we can get temperatures above 100
+        // without including the "C".
+        g.drawChars(test, 0, 3, 2, y);
+    }
 }
 
 bool CPUStatus::handleTimer(YTimer *t) {

--- a/src/acpustatus.h
+++ b/src/acpustatus.h
@@ -25,7 +25,8 @@ public:
         bool cpustatusShowRamUsage = 0,
 	bool cpustatusShowSwapUsage = 0,
 	bool cpustatusShowAcpiTemp = 0,
-	bool cpustatusShowCpuFreq = 0);
+	bool cpustatusShowCpuFreq = 0,
+	bool cpustatusShowAcpiTempInGraph = 0);
     virtual ~CPUStatus();
     
     virtual void paint(Graphics &g, const YRect &r);
@@ -46,7 +47,8 @@ private:
     YColor *color[IWM_STATES];
     YTimer *fUpdateTimer;
     YSMListener *smActionListener;
-    bool ShowRamUsage, ShowSwapUsage, ShowAcpiTemp, ShowCpuFreq;
+    bool ShowRamUsage, ShowSwapUsage, ShowAcpiTemp, ShowCpuFreq,
+         ShowAcpiTempInGraph;
     int m_nCachedFd;
 
     YColor *tempColor;

--- a/src/acpustatus.h
+++ b/src/acpustatus.h
@@ -48,6 +48,9 @@ private:
     YSMListener *smActionListener;
     bool ShowRamUsage, ShowSwapUsage, ShowAcpiTemp, ShowCpuFreq;
     int m_nCachedFd;
+
+    YColor *tempColor;
+    static ref<YFont> tempFont;
 };
 #else
 #undef CONFIG_APPLET_CPU_STATUS

--- a/src/default.h
+++ b/src/default.h
@@ -73,6 +73,7 @@ XIV(bool, taskBarShowCPUStatus,                 true)
 XIV(bool, cpustatusShowRamUsage,                true)
 XIV(bool, cpustatusShowSwapUsage,               true)
 XIV(bool, cpustatusShowAcpiTemp,                true)
+XIV(bool, cpustatusShowAcpiTempInGraph,         false)
 XIV(bool, cpustatusShowCpuFreq,                 true)
 XIV(bool, taskBarShowMEMStatus,                 true)
 XIV(bool, taskBarShowNetStatus,                 true)
@@ -316,6 +317,7 @@ cfoption icewm_preferences[] = {
     OBV("CPUStatusShowRamUsage",                &cpustatusShowRamUsage,         "Show RAM usage in CPU status tool tip"),
     OBV("CPUStatusShowSwapUsage",               &cpustatusShowSwapUsage,        "Show swap usage in CPU status tool tip"),
     OBV("CPUStatusShowAcpiTemp",                &cpustatusShowAcpiTemp,         "Show ACPI temperature in CPU status tool tip"),
+    OBV("CPUStatusShowAcpiTempInGraph",         &cpustatusShowAcpiTempInGraph,  "Show ACPI temperature in CPU status bar"),
     OBV("CPUStatusShowCpuFreq",                 &cpustatusShowCpuFreq,          "Show CPU frequency in CPU status tool tip"),
     OBV("TaskBarShowMEMStatus",                 &taskBarShowMEMStatus,          "Show memory usage status on task bar (Linux only)"),
     OBV("TaskBarShowNetStatus",                 &taskBarShowNetStatus,          "Show network status on task bar (Linux only)"),

--- a/src/themable.h
+++ b/src/themable.h
@@ -62,6 +62,7 @@ XFV(const char *, minimizedWindowFontName,      FONT(120), "sans-serif:size=12")
 XFV(const char *, listBoxFontName,              FONT(120), "sans-serif:size=12")
 XFV(const char *, labelFontName,                FONT(140), "sans-serif:size=12")
 XFV(const char *, clockFontName,                TTFONT(140), "monospace:size=12")
+XFV(const char *, tempFontName,                 TTFONT(140), "monospace:size=12")
 XFV(const char *, apmFontName,                  TTFONT(140), "monospace:size=12")
 XFV(const char *, inputFontName,                TTFONT(140), "monospace:size=12")
 
@@ -143,6 +144,7 @@ XSV(const char *, clrCpuIoWait,                 "rgb:60/00/60")
 XSV(const char *, clrCpuSoftIrq,                "rgb:00/FF/FF")
 XSV(const char *, clrCpuNice,                   "rgb:00/00/FF")
 XSV(const char *, clrCpuIdle,                   "rgb:00/00/00")
+XSV(const char *, clrCpuTemp,                   "rgb:60/60/C0")
 XSV(const char *, clrMemUser,                   "rgb:40/40/80")
 XSV(const char *, clrMemBuffers,                "rgb:60/60/C0")
 XSV(const char *, clrMemCached,                 "rgb:80/80/FF")
@@ -219,6 +221,7 @@ cfoption icewm_themable_preferences[] = {
     OFV("ListBoxFontName",                      &listBoxFontName,               ""),
     OFV("ToolTipFontName",                      &toolTipFontName,               ""),
     OFV("ClockFontName",                        &clockFontName,                 ""),
+    OFV("TempFontName",                         &tempFontName,                  ""),
     OFV("ApmFontName",                          &apmFontName,                   ""),
     OFV("InputFontName",                        &inputFontName,                 ""),
     OFV("LabelFontName",                        &labelFontName,                 ""),
@@ -319,6 +322,7 @@ cfoption icewm_themable_preferences[] = {
     OSV("ColorCPUStatusSoftIrq",                &clrCpuSoftIrq,                 "Soft Interrupts on the CPU monitor"),
     OSV("ColorCPUStatusNice",                   &clrCpuNice,                    "Nice load on the CPU monitor"),
     OSV("ColorCPUStatusIdle",                   &clrCpuIdle,                    "Idle (non) load on the CPU monitor, leave empty to force transparency"),
+    OSV("ColorCPUStatusTemp",                   &clrCpuTemp,                    "Temperature of the CPU"),
 #endif
 #ifdef CONFIG_APPLET_MEM_STATUS
     OSV("ColorMEMStatusUser",                   &clrMemUser,                    "User program usage in the memory monitor"),

--- a/src/wmtaskbar.cc
+++ b/src/wmtaskbar.cc
@@ -449,7 +449,8 @@ void TaskBar::initApplets() {
 #ifdef CONFIG_APPLET_CPU_STATUS
     if (taskBarShowCPUStatus)
         fCPUStatus = new CPUStatus(smActionListener, this, cpustatusShowRamUsage, cpustatusShowSwapUsage,
-																	 cpustatusShowAcpiTemp, cpustatusShowCpuFreq);
+																	 cpustatusShowAcpiTemp, cpustatusShowCpuFreq,
+																	 cpustatusShowAcpiTempInGraph);
     else
         fCPUStatus = 0;
 #endif


### PR DESCRIPTION
Hello,

This is useful to me and I think it would be useful to others. The option is controlled using a configuration variable that can be set in the preferences file: "CPUStatusShowAcpiTempInGraph". There should be no changes to functionality if the option is disabled, and it is by default.

The default color doesn't clash too much, but it could be changed if desired.
