### PR TITLE
Start shutdown and reboot commands in background

### DIFF
--- a/src/wmmgr.cc
+++ b/src/wmmgr.cc
@@ -3011,16 +3011,30 @@ void YWindowManager::updateUserTime(Time time) {
     }
 }
 
+void YWindowManager::execAfterFork(const char *command) {
+    pid_t pid = fork();
+    switch(pid) {
+    case -1: /* Failed */
+        warn("fork failed (%d)", errno);
+        return;
+    case 0: /* Child */
+        execl("/bin/sh", "sh", "-c", command, (char *) 0);
+        return; /* Never reached */
+    default: /* Parent */
+        return;
+    }
+}
+
 void YWindowManager::checkLogout() {
     if (fShuttingDown && !haveClients()) {
+        fShuttingDown = false; /* Only run the command once */
+
         if (rebootOrShutdown == 1 && rebootCommand && rebootCommand[0]) {
             msg("reboot... (%s)", rebootCommand);
-            if (system(rebootCommand) == -1)
-		return;
+            execAfterFork(rebootCommand);
         } else if (rebootOrShutdown == 2 && shutdownCommand && shutdownCommand[0]) {
             msg("shutdown ... (%s)", shutdownCommand);
-            if (system(shutdownCommand) == -1)
-		return;
+            execAfterFork(shutdownCommand);
         } else
             app->exit(0);
     }

--- a/src/wmmgr.h
+++ b/src/wmmgr.h
@@ -188,6 +188,7 @@ public:
 
     void wmCloseSession();
     void exitAfterLastClient(bool shuttingDown);
+    void execAfterFork(const char *command);
     void checkLogout();
 
     virtual void resetColormap(bool active);


### PR DESCRIPTION
When polkit is enabled, systemctl may in turn wait for the
graphical password prompt to return. The created window cannot
be handled by icewm as it is busy with systemctl.
This avoids this deadlock by starting systemctl in background.
Fixes #80.

I tested this by setting a graphical application as `ShutdownCommand` in `/etc/icewm/preferences`.
