### PR TITLE
Fixes /proc/stat FD_CLOEXEC, MappingNotify warnings, handling dup/closing of fds.

### DIFF
--- a/po/ar.po
+++ b/po/ar.po
@@ -108,12 +108,12 @@ msgstr "خطأ فحص البريد."
 #: src/amailbox.cc:457
 #, c-format
 msgid "%ld mail message."
-msgstr "%رسالة معرف البريد."
+msgstr "%ld رسالة معرف البريد."
 
 #: src/amailbox.cc:458
 #, c-format
 msgid "%ld mail messages."
-msgstr "%lرسالة معرف البريد."
+msgstr "%ld رسالة معرف البريد."
 
 #: src/apppstatus.cc:204
 #, c-format

--- a/src/acpustatus.cc
+++ b/src/acpustatus.cc
@@ -415,8 +415,12 @@ void CPUStatus::getStatus() {
     unsigned long long cur[IWM_STATES];
     int len, s;
     int &fd = m_nCachedFd;
-    if(fd<0)
+    if (fd < 0) {
     	fd = open("/proc/stat", O_RDONLY);
+        if (fd < 0)
+            return;
+        fcntl(fd, F_SETFD, FD_CLOEXEC);
+    }
     else
     	lseek(fd, 0L, SEEK_SET);
 
@@ -428,8 +432,6 @@ void CPUStatus::getStatus() {
     cpu[taskBarCPUSamples - 1][IWM_SYS] = 0;
     cpu[taskBarCPUSamples - 1][IWM_IDLE] = 0;
 
-    if (fd < 0)
-        return;
     len = read(fd, buf, sizeof(buf) - 1);
     if (len < 0) {
         close(fd);

--- a/src/iceview.cc
+++ b/src/iceview.cc
@@ -577,18 +577,25 @@ public:
 
         int fd = open(fPath, O_RDONLY);
         if (fd == -1)
-            return ;
-        if (fstat(fd, &sb) != 0)
-            return ;
+            return;
+        if (fstat(fd, &sb) != 0) {
+            close(fd);
+            return;
+        }
         int len = sb.st_size;
         char *buf;
 
         if ((buf = (char *)mmap(0, len, PROT_READ, MAP_SHARED, fd, 0)) == 0) {
             buf = (char *)malloc(len);
-            if (buf == 0)
-                return ;
-            if ((len = read(fd, buf, len)) < 0)
-                return ;
+            if (buf == 0) {
+                close(fd);
+                return;
+            }
+            if ((len = read(fd, buf, len)) < 0) {
+                free(buf);
+                close(fd);
+                return;
+            }
         }
 
 

--- a/src/wmoption.cc
+++ b/src/wmoption.cc
@@ -399,17 +399,22 @@ void loadWinOptions(upath optFile) {
 
     struct stat sb;
 
-    if (fstat(fd, &sb) == -1)
-        return ;
+    if (fstat(fd, &sb) == -1) {
+        close(fd);
+        return;
+    }
 
     int len = sb.st_size;
 
     char *buf = new char[len + 1];
-    if (buf == 0)
-        return ;
+    if (buf == 0) {
+        close(fd);
+        return;
+    }
 
     if ((len = read(fd, buf, len)) < 0) {
         delete[] buf;
+        close(fd);
         return;
     }
 

--- a/src/wmprog.cc
+++ b/src/wmprog.cc
@@ -651,10 +651,11 @@ void loadMenusProg(
         switch ((child_pid = fork())) {
         case 0:
             close(0);
-            close(1);
+            open("/dev/null", O_RDONLY);
 
             close(fds[0]);
             dup2(fds[1], 1);
+            close(fds[1]);
 
             execvp(command, argv);
             _exit(99);

--- a/src/yapp.cc
+++ b/src/yapp.cc
@@ -625,13 +625,12 @@ int YApplication::startWorker(int socket, const char *path, const char *const *a
         sigaddset(&signalMask, SIGHUP);
         sigprocmask(SIG_UNBLOCK, &signalMask, NULL);
 
-        close(0);
         if (dup2(socket, 0) != 0)
             _exit(1);
-        close(1);
         if (dup2(socket, 1) != 1)
             _exit(1);
-        close(socket);
+        if (socket > 1)
+            close(socket);
 
         closeFiles();
 

--- a/src/yconfig.cc
+++ b/src/yconfig.cc
@@ -337,17 +337,22 @@ void YConfig::loadConfigFile(cfoption *options, upath fileName) {
 
     struct stat sb;
 
-    if (fstat(fd, &sb) == -1)
-        return ;
+    if (fstat(fd, &sb) == -1) {
+        close(fd);
+        return;
+    }
 
     int len = sb.st_size;
 
     char *buf = new char[len + 1];
-    if (buf == 0)
-        return ;
+    if (buf == 0) {
+        close(fd);
+        return;
+    }
 
     if ((len = read(fd, buf, len)) < 0) {
         delete[] buf;
+        close(fd);
         return;
     }
 

--- a/src/ypipereader.cc
+++ b/src/ypipereader.cc
@@ -37,7 +37,7 @@ int YPipeReader::spawnvp(const char *prog, char **args) {
         close(fds[0]);
         dup2(fds[1], 1);
         int devnull = open("/dev/null", O_RDONLY);
-        if (devnull != -1) {
+        if (devnull > 0) {
             dup2(devnull, 0);
             close(devnull);
         }

--- a/src/yxapp.cc
+++ b/src/yxapp.cc
@@ -839,7 +839,7 @@ void YXApplication::afterWindowEvent(XEvent & /*xev*/) {
 
 bool YXApplication::filterEvent(const XEvent &xev) {
     if (xev.type == MappingNotify) {
-        msg("MappingNotify");
+        MSG(("MappingNotify"));
         XMappingEvent xmapping = xev.xmapping;
         XRefreshKeyboardMapping(&xmapping);
 

--- a/src/yxtray.cc
+++ b/src/yxtray.cc
@@ -75,21 +75,21 @@ void YXTrayProxy::handleClientMessage(const XClientMessageEvent &message) {
     if (message.message_type == _NET_SYSTEM_TRAY_OPCODE) {
         //printf("message data %ld %ld %ld %ld %ld\n", message.data.l[0], message.data.l[1], message.data.l[2], message.data.l[3], message.data.l[4]);
         if (message.data.l[1] == SYSTEM_TRAY_REQUEST_DOCK) {
-            msg("systemTrayRequestDock");
+            MSG(("systemTrayRequestDock"));
             fTray->trayRequestDock(message.data.l[2]);
         } else if (message.data.l[1] == SYSTEM_TRAY_BEGIN_MESSAGE) {
-            msg("systemTrayBeginMessage");
+            MSG(("systemTrayBeginMessage"));
             //fTray->trayBeginMessage();
         } else if (message.data.l[1] == SYSTEM_TRAY_CANCEL_MESSAGE) {
-            msg("systemTrayCancelMessage");
+            MSG(("systemTrayCancelMessage"));
             //fTray->trayCancelMessage();
         } else {
-            msg("systemTray???Message");
+            MSG(("systemTray???Message"));
         }
     } else if (message.message_type == _NET_SYSTEM_TRAY_MESSAGE_DATA) {
-        msg("systemTrayMessageData");
+        MSG(("systemTrayMessageData"));
     } else {
-        msg("handleClientMessage: do nothing");
+        MSG(("handleClientMessage: do nothing"));
     }
 }
 


### PR DESCRIPTION
This branch fixes the cause for the IceWM warning messages for /proc/stat:
IceWM: Warning: File still open: fd=6, target='/proc/stat' (missing FD_CLOEXEC?)
IceWM: Warning: Closing file descriptor: 6

Also a fix for the MappingNotify warnings where a 'msg' should have been a 'MSG'.

And a 2 fixes for errors in po/ar.po.

And more small fixes for properly handling dup-ing and closing of file descriptors.