### PR TITLE
Revert "Set the time format to '%T' for some locales when ledclock/co…

### DIFF
--- a/src/aclock.cc
+++ b/src/aclock.cc
@@ -37,12 +37,9 @@ ref<YFont> YClock::clockFont;
 
 extern ref<YPixmap> taskbackPixmap;
 static YColor *taskBarBg = 0;
-static char const *AppletClockTimeFmt = "%T";
 
 inline char const * strTimeFmt(struct tm const & t) {
-    if (PixColon == null)
-        return (fmtTimeAlt && (t.tm_sec & 1) ? fmtTimeAlt : fmtTime);
-    return AppletClockTimeFmt;
+    return (fmtTimeAlt && (t.tm_sec & 1) ? fmtTimeAlt : fmtTime);
 }
 
 YClock::YClock(YSMListener *smActionListener, YWindow *aParent): YWindow(aParent) {


### PR DESCRIPTION
…lon.xpm is loaded."

This reverts commit 74ad056ab30df628de05c0b4fc0da310e16f894b.

This code always sets the time format to '%T', unless you remove the
colon.xpm from the default location.

I'm not sure why one would want to set the time format based on the existence of the colon pixmap, anyway.