### PR TITLE
po/el.po: fix msgmerge error

### DIFF
--- a/po/el.po
+++ b/po/el.po
@@ -118,11 +118,6 @@ msgstr "Φορτίο: "
 msgid "%s: %llu %llu %llu %llu %llu %llu %llu %llu"
 msgstr "%s: %llu %llu %llu %llu %llu %llu %llu %llu"
 
-#: src/acpustatus.cc:695
-#, c-format
-msgid "%s: %llu %llu %llu %llu %llu %llu %llu %llu"
-msgstr ""
-
 #: src/amailbox.cc:77
 #, c-format
 msgid "Invalid mailbox protocol: \"%s\""


### PR DESCRIPTION
Hi!
There was an error in the build:

[ 59%] Updated: /usr/src/RPM/BUILD/icewm-githubmod/BUILD/po/el.po
/usr/src/RPM/BUILD/icewm-githubmod/po/el.po:123: duplicate message definition...
/usr/src/RPM/BUILD/icewm-githubmod/po/el.po:119: ...this is the location of the first definition
[ 60%] Generating nb.gmo
msgmerge: found 1 fatal error
make[2]: *** [po/el.po] Error 1
make[2]: Leaving directory `/usr/src/RPM/BUILD/icewm-githubmod/BUILD'
make[1]: *** [po/CMakeFiles/el.gmo.dir/all] Error 2

Fix:
