### PR TITLE
remove obsolete pragmas (interface + implementation).

### DIFF
--- a/src/mstring.cc
+++ b/src/mstring.cc
@@ -5,11 +5,6 @@
  */
 #include "config.h"
 
-// XXX: find a good reason for keeping this pragma. Until that happens, make it play nicely with LLVM
-#if defined(__GNUC__) && ! defined(__clang_major__)
-#pragma implementation
-#endif
-
 #include "mstring.h"
 #include <string.h>
 #include <stdarg.h>

--- a/src/mstring.h
+++ b/src/mstring.h
@@ -5,11 +5,6 @@
 #include "ref.h"
 #include <string.h>
 
-// XXX: find a good reason for keeping this pragma. Until that happens, make it play nicely with LLVM
-#if defined(__GNUC__) && ! defined(__clang_major__)
-#pragma interface
-#endif
-
 struct MStringData {
     int fRefCount;
     char fStr[];

--- a/src/upath.cc
+++ b/src/upath.cc
@@ -5,11 +5,6 @@
  */
 #include "config.h"
 
-// XXX: find a good reason for keeping this pragma. Until that happens, make it play nicely with LLVM
-#if defined(__GNUC__) && ! defined(__clang_major__)
-#pragma implementation
-#endif
-
 #include "upath.h"
 #include "unistd.h"
 #include <sys/types.h>

--- a/src/ypoint.h
+++ b/src/ypoint.h
@@ -1,11 +1,6 @@
 #ifndef __YPOINT_H
 #define __YPOINT_H
 
-// XXX: find a good reason for keeping this pragma. Until that happens, make it play nicely with LLVM
-#if defined(__GNUC__) && ! defined(__clang_major__)
-#pragma interface
-#endif
-
 class YPoint {
 public:
     YPoint(): fX(0), fY(0) { }


### PR DESCRIPTION
These pragmas are obsolete since gcc 2.7.2 (November 26, 1995) 
and can therefore be deleted. See:
https://gcc.gnu.org/onlinedocs/gcc/C_002b_002b-Interface.html
and:
https://gcc.gnu.org/ml/gcc/2004-06/msg00100.html
