### PR TITLE
Mstring and precondition cleanup, remove tTempBuf, strtest.cc implemented.

### DIFF
--- a/src/apppstatus.cc
+++ b/src/apppstatus.cc
@@ -482,7 +482,7 @@ bool NetStatus::isUp() {
 
 #else
     struct ifreq ifr;
-    fNetDev.copy(ifr.ifr_name, IFNAMSIZ);
+    fNetDev.copyTo(ifr.ifr_name, IFNAMSIZ);
     bool bUp = (ioctl(s, SIOCGIFFLAGS, &ifr) >= 0 && (ifr.ifr_flags & IFF_UP));
     close(s);
     return bUp;
@@ -620,7 +620,7 @@ void NetStatus::getCurrent(long *in, long *out) {
 
     s = socket(AF_INET, SOCK_DGRAM, 0);
     if (s != -1) {
-	fNetDev.copy(ifdr.ifdr_name, sizeof(ifdr.ifdr_name));
+	fNetDev.copyTo(ifdr.ifdr_name, sizeof(ifdr.ifdr_name));
         if (ioctl(s, SIOCGIFDATA, &ifdr) != -1) {
             cur_ibytes = ifi->ifi_ibytes;
             cur_obytes = ifi->ifi_obytes;
@@ -635,7 +635,7 @@ void NetStatus::getCurrent(long *in, long *out) {
 
     s = socket(AF_INET, SOCK_DGRAM, 0);
     if (s != -1) {
-	fNetDev.copy(ifdr.ifr_name, sizeof(ifdr.ifr_name));
+	fNetDev.copyTo(ifdr.ifr_name, sizeof(ifdr.ifr_name));
         ifdr.ifr_data = (caddr_t) &ifi;
         if (ioctl(s, SIOCGIFDATA, &ifdr) != -1) {
             cur_ibytes = ifi.ifi_ibytes;

--- a/src/base.h
+++ b/src/base.h
@@ -95,7 +95,7 @@ static char const * itoa(T i, bool sign = false) {
 void die(int exitcode, char const *msg, ...);
 void warn(char const *msg, ...);
 void msg(char const *msg, ...);
-void precondition(char const *msg, ...);
+void precondition(const char *expr, const char *file, int line);
 void show_backtrace();
 
 #define DEPRECATE(x) \

--- a/src/debug.h
+++ b/src/debug.h
@@ -7,11 +7,7 @@ extern bool debug_z;
 
 #define DBG if (debug)
 #define MSG(x) DBG msg x
-#define PRECONDITION(x) \
-    if (!(x)) \
-    do { \
-    precondition("PRECONDITION FAILED at %s:%d: (" #x ")", __FILE__, __LINE__); \
-    } while (0)
+#define PRECONDITION(x) if (x); else precondition( #x , __FILE__, __LINE__)
 #else
 #define DBG if (0)
 #define MSG(x)

--- a/src/icesm.cc
+++ b/src/icesm.cc
@@ -14,6 +14,14 @@ char const *ApplicationName = ICESMEXE;
 unsigned short startup_phase(0); // 0: run tray, 1: run startup script
 
 class SessionManager: public YApplication {
+private:
+    void remove_trailing_spaces(char *line) {
+        size_t len = strlen(line);
+        while (len > 0 && isspace((unsigned char) line[len - 1])) {
+            line[--len] = 0;
+        }
+    }
+
 public:
     SessionManager(int *argc, char ***argv): YApplication(argc, argv) {
         logout = false;
@@ -36,17 +44,11 @@ public:
             FILE *ef = fopen(cs.c_str(), "r");
             if(!ef)
                 return;
-            tTempBuf scratch(500);
-            if(!scratch)
-                return;
-            scratch.p[499] = 0;
-            while(!feof(ef) && !ferror(ef))
+            char scratch[500];
+            while (fgets(scratch, 500, ef))
             {
-                char *line(scratch);
-                if (!fgets(line, 497, ef))
-                    break;
-                for(int tlen = strlen(line)-1; isspace((unsigned)line[tlen]) && tlen; --tlen)
-                    line[tlen] = 0;
+                char *line = scratch;
+                remove_trailing_spaces(line);
 #ifdef HAVE_WORDEXP
                 wordexp_t w;
                 wordexp(line, &w, 0);

--- a/src/misc.cc
+++ b/src/misc.cc
@@ -305,14 +305,9 @@ void die(int exitcode, char const *msg, ...) {
     exit(exitcode);
 }
 
-void precondition(char const *msg, ...) {
-    fprintf(stderr, "%s: ", ApplicationName);
-
-    va_list ap;
-    va_start(ap, msg);
-    vfprintf(stderr, msg, ap);
-    va_end(ap);
-    fputs("\n", stderr);
+void precondition(const char *expr, const char *file, int line) {
+    fprintf(stderr, "%s: PRECONDITION FAILED at %s:%d: ( %s )\n",
+            ApplicationName, file, line, expr);
     fflush(stderr);
 
     show_backtrace();

--- a/src/mstring.cc
+++ b/src/mstring.cc
@@ -88,12 +88,12 @@ mstring mstring::operator+(const mstring& rv) const {
     return mstring(ud, 0, newCount);
 }
 
-mstring mstring::operator+=(const mstring& rv) {
+mstring& mstring::operator+=(const mstring& rv) {
     *this = *this + rv;
     return *this;
 }
 
-mstring mstring::operator=(const mstring& rv) {
+mstring& mstring::operator=(const mstring& rv) {
     if (fStr != rv.fStr) {
         if (fStr) release();
         fStr = rv.fStr;
@@ -104,7 +104,7 @@ mstring mstring::operator=(const mstring& rv) {
     return *this;
 }
 
-mstring mstring::operator=(const class null_ref &) {
+mstring& mstring::operator=(const class null_ref &) {
     if (fStr)
         release();
     fStr = 0;
@@ -183,6 +183,8 @@ int mstring::charAt(int pos) const {
 bool mstring::startsWith(const mstring &s) const {
     if (length() < s.length())
         return false;
+    if (s.length() == 0)
+        return true;
     if (memcmp(data(), s.data(), s.length()) == 0)
         return true;
     return false;
@@ -191,12 +193,16 @@ bool mstring::startsWith(const mstring &s) const {
 bool mstring::endsWith(const mstring &s) const {
     if (length() < s.length())
         return false;
+    if (s.length() == 0)
+        return true;
     if (memcmp(data() + length() - s.length(), s.data(), s.length()) == 0)
         return true;
     return false;
 }
 
 int mstring::indexOf(char ch) const {
+    if (length() == 0)
+        return -1;
     char *s = (char *)memchr(data(), ch, fCount);
     if (s == NULL)
         return -1;
@@ -212,20 +218,25 @@ int mstring::compareTo(const mstring &s) const {
     if (s.length() > length()) {
         return -1;
     } else if (s.length() == length()) {
+        if (length() == 0)
+            return 0;
         return memcmp(s.data(), data(), fCount);
     } else {
         return 1;
     }
 #else
-    int res = memcmp(data(), s.data(), min(s.length(), length()));
-    if (res)
-       return res;
+    int minlen = min(s.length(), length());
+    if (minlen > 0) {
+        int res = memcmp(data(), s.data(), minlen);
+        if (res)
+           return res;
+    }
     return length() - s.length();
 #endif
 }
 
 bool mstring::copyTo(char *dst, size_t len) const {
-    if (len > 0) {
+    if (len > 0 && fCount > 0) {
         size_t minlen = min(len - 1, (size_t) fCount);
         memcpy(dst, data(), minlen);
         dst[minlen] = 0;

--- a/src/mstring.cc
+++ b/src/mstring.cc
@@ -149,14 +149,13 @@ mstring mstring::substring(int pos, int len) const {
 
 bool mstring::split(unsigned char token, mstring *left, mstring *remain) const {
     PRECONDITION(token < 128);
-    for (int i = 0; i < length(); ++i) {
-        if ((unsigned char) fStr->fStr[fOffset + i] == token) {
-            mstring l = substring(0, i);
-            mstring r = substring(i + 1, length() - i - 1);
-            *left = l;
-            *remain = r;
-            return true;
-        }
+    int i = indexOf((char) token);
+    if (i >= 0) {
+        mstring l = substring(0, i);
+        mstring r = substring(i + 1, length() - i - 1);
+        *left = l;
+        *remain = r;
+        return true;
     }
     return false;
 }

--- a/src/mstring.cc
+++ b/src/mstring.cc
@@ -7,10 +7,27 @@
 
 #include "mstring.h"
 #include <string.h>
-#include <stdarg.h>
-#include <stdio.h>
 #include <stdlib.h>
+#include <ctype.h>
 #include "base.h"
+
+MStringData *MStringData::alloc(int length) {
+    size_t size = sizeof(MStringData) + (size_t) length + 1;
+    MStringData *ud = (MStringData *) malloc(size);
+    ud->fRefCount = 0;
+    return ud;
+}
+
+MStringData *MStringData::create(const char *str, int length) {
+    MStringData *ud = MStringData::alloc(length);
+    strncpy(ud->fStr, str, length);
+    ud->fStr[length] = 0;
+    return ud;
+}
+
+MStringData *MStringData::create(const char *str) {
+    return create(str, (int) strlen(str));
+}
 
 cstring::cstring(const mstring &s): str(s) {
     if (str.fStr) {
@@ -30,19 +47,6 @@ mstring::mstring(MStringData *fStr, int fOffset, int fCount):
     if (fStr) acquire(); 
 }
 
-#if 0
-mstring::mstring(const mstring &r):
-    fStr(r.fStr),
-    fOffset(r.fOffset),
-    fCount(r.fCount)
-
-{
-    PRECONDITION(fOffset >= 0);
-    PRECONDITION(fCount >= 0);
-    if (fStr) acquire();
-}
-#endif
-
 mstring::mstring(const char *str) {
     init(str, str ? strlen(str) : 0);
 }
@@ -53,17 +57,9 @@ mstring::mstring(const char *str, int len) {
 
 void mstring::init(const char *str, int len) {
     if (str) {
-        int count = len;
-        MStringData *ud = 
-            (MStringData *)malloc(sizeof(MStringData) + count + 1);
-       
-        ud->fRefCount = 0;
-        memcpy(ud->fStr, str, count);
-        ud->fStr[count] = 0;
-        
-        fStr = ud;
+        fStr = MStringData::create(str, len);
         fOffset = 0;
-        fCount = count;
+        fCount = len;
         acquire();
     } else {
         fStr = 0;
@@ -79,6 +75,22 @@ void mstring::destroy() {
 mstring::~mstring() {
     if (fStr)
         release();
+}
+
+mstring mstring::operator+(const mstring& rv) const {
+    if (!length()) return rv;
+    if (!rv.length()) return *this;
+    int newCount = length() + rv.length();
+    MStringData *ud = MStringData::alloc(newCount);
+    memcpy(ud->fStr, data(), length());
+    memcpy(ud->fStr + length(), rv.data(), rv.length());
+    ud->fStr[newCount] = 0;
+    return mstring(ud, 0, newCount);
+}
+
+mstring mstring::operator+=(const mstring& rv) {
+    *this = *this + rv;
+    return *this;
 }
 
 mstring mstring::operator=(const mstring& rv) {
@@ -108,6 +120,7 @@ mstring mstring::fromMultiByte(const char *str, int len) {
 mstring mstring::fromMultiByte(const char *str) {
     return newstr(str);
 }
+
 mstring mstring::newstr(const char *str) {
     return newstr(str, str ? strlen(str) : 0);
 }
@@ -115,51 +128,35 @@ mstring mstring::newstr(const char *str) {
 mstring mstring::newstr(const char *str, int count) {
     PRECONDITION(count >= 0);
     PRECONDITION(str != 0 || count == 0);
-    MStringData *ud = (MStringData *)malloc(sizeof(MStringData) + count + 1);
 
-    ud->fRefCount = 0;
-    memcpy(ud->fStr, str, count);
-    ud->fStr[count] = 0;
-
+    MStringData *ud = MStringData::create(str, count);
     return mstring(ud, 0, count);
 }
 
-mstring mstring::substring(int pos) {
+mstring mstring::substring(int pos) const {
     PRECONDITION(pos >= 0);
     PRECONDITION(pos <= length());
     return mstring(fStr, fOffset + pos, fCount - pos);
 }
 
-mstring mstring::substring(int pos, int len) {
+mstring mstring::substring(int pos, int len) const {
     PRECONDITION(pos >= 0);
     PRECONDITION(len >= 0);
-    PRECONDITION(pos <= length());
     PRECONDITION(pos + len <= length());
 
     return mstring(fStr, fOffset + pos, len);
 }
 
 bool mstring::split(unsigned char token, mstring *left, mstring *remain) const {
-    int i = fOffset;
-    int e = fOffset + fCount;
-    int c = 0;
-    unsigned char ch;
-
     PRECONDITION(token < 128);
-    while (i < e) {
-        ch = fStr->fStr[i];
-        if (ch == token) {
-            mstring l(fStr, fOffset, i - fOffset);
-            mstring r(fStr, i + 1, e - i - 1);
-
+    for (int i = 0; i < length(); ++i) {
+        if ((unsigned char) fStr->fStr[fOffset + i] == token) {
+            mstring l = substring(0, i);
+            mstring r = substring(i + 1, length() - i - 1);
             *left = l;
             *remain = r;
             return true;
         }
-        if (ch <= 0x7F || (ch >= 0xC0 && ch <= 0xFD)) {
-            c++;
-        }
-        i++;
     }
     return false;
 }
@@ -215,87 +212,54 @@ int mstring::compareTo(const mstring &s) const {
     if (s.length() > length()) {
         return -1;
     } else if (s.length() == length()) {
-        if (fCount == 0)
-            return 0;
-        else
-            return memcmp(s.data(), data(), fCount);
+        return memcmp(s.data(), data(), fCount);
     } else {
         return 1;
     }
 #else
-    int res=memcmp(data(), s.data(), min(s.length(), length()));
-    if (s.length() == length())
+    int res = memcmp(data(), s.data(), min(s.length(), length()));
+    if (res)
        return res;
-    if(res) // different length, left part already not equal
-       return res;
-    return length()-s.length();
+    return length() - s.length();
 #endif
 }
 
-bool mstring::copy(char *dst, size_t len) const {
-    strncpy(dst, data(), len);
-    if ((size_t) fCount < len)
-	dst[fCount] = '\0';
-    dst[len - 1] = '\0';
+bool mstring::copyTo(char *dst, size_t len) const {
+    if (len > 0) {
+        size_t minlen = min(len - 1, (size_t) fCount);
+        memcpy(dst, data(), minlen);
+        dst[minlen] = 0;
+    }
     return (size_t) fCount < len;
 }
 
-mstring mstring::replace(int position, int len, const mstring &insert) {
+mstring mstring::replace(int position, int len, const mstring &insert) const {
     PRECONDITION(position >= 0);
     PRECONDITION(len >= 0);
     PRECONDITION(position + len <= length());
-    int count = length() - len + insert.length();
-
-    MStringData *ud = (MStringData *)malloc(sizeof(MStringData) + count + 1);
-
-    ud->fRefCount = 0;
-    memcpy(ud->fStr, data(), position);
-    memcpy(ud->fStr + position, insert.data(), insert.fCount);
-    memcpy(ud->fStr + position + insert.fCount, data() + position + len, fCount - len - position);
-    ud->fStr[count] = 0;
-    return mstring(ud, 0, count);
+    return substring(0, position) + insert
+        + substring(position + len, length() - position - len);
 }
 
-mstring mstring::remove(int position, int len) {
-    PRECONDITION(position >= 0);
-    PRECONDITION(len >= 0);
-    PRECONDITION(position + len <= length());
-    int count = length() - len;
-
-    MStringData *ud = (MStringData *)malloc(sizeof(MStringData) + count + 1);
-
-    ud->fRefCount = 0;
-    memcpy(ud->fStr, data(), position);
-    memcpy(ud->fStr + position, data() + position + len, fCount - len - position);
-    ud->fStr[count] = 0;
-    return mstring(ud, 0, count);
+mstring mstring::remove(int position, int len) const {
+    return replace(position, len, mstring(null));
 }
 
-mstring mstring::insert(int position, const mstring &s) {
+mstring mstring::insert(int position, const mstring &s) const {
     return replace(position, 0, s);
 }
 
-mstring mstring::append(const mstring &s) {
-    return replace(length(), 0, s);
+mstring mstring::append(const mstring &s) const {
+    return *this + s;
 }
 
 mstring mstring::trim() const {
-    int pos = 0;
-    int len = fCount;
-    while (pos < len) {
-        char ch = fStr->fStr[fOffset + pos];
-        if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r') {
-            pos++;
-            len--;
-        } else
-            break;
+    int k = 0, n = length();
+    while (k < n && isspace((unsigned char) charAt(k))) {
+        ++k;
     }
-    while (len > 0) {
-        char ch = fStr->fStr[fOffset + pos + len - 1];
-        if (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r') {
-            len--;
-        } else
-            break;
+    while (k < n && isspace((unsigned char) charAt(n - 1))) {
+        --n;
     }
-    return mstring(fStr, fOffset + pos, len);
+    return substring(k, n - k);
 }

--- a/src/mstring.h
+++ b/src/mstring.h
@@ -61,8 +61,8 @@ public:
 
     int length() const { return fCount; }
 
-    mstring operator=(const mstring& rv);
-    mstring operator+=(const mstring& rv);
+    mstring& operator=(const mstring& rv);
+    mstring& operator+=(const mstring& rv);
     mstring operator+(const mstring& rv) const;
 
     bool operator==(const mstring &rv) const { return equals(rv); }
@@ -70,7 +70,7 @@ public:
     bool operator==(const class null_ref &) const { return fStr == 0; }
     bool operator!=(const class null_ref &) const { return fStr != 0; }
 
-    mstring operator=(const class null_ref &);
+    mstring& operator=(const class null_ref &);
     mstring substring(int pos) const;
     mstring substring(int pos, int len) const;
 

--- a/src/strtest.cc
+++ b/src/strtest.cc
@@ -34,6 +34,8 @@ int main(int argc, char **argv)
     mstring e(null);
     expect(e, "");
     assert(e, e.length() == 0);
+    assert(e, e == null);
+    assert(e, e.indexOf(' ') == -1);
 
     mstring m("abc", 0);
     expect(m, "");

--- a/src/strtest.cc
+++ b/src/strtest.cc
@@ -98,6 +98,8 @@ int main(int argc, char **argv)
     assert(z, z.endsWith(""));
 
     mstring l(null), r(null);
+    e = null;
+    assert(e, e.split(0, &l, &r) == false);
     assert(z, z.split('o', &l, &r));
     expect(z, "foofoo");
     expect(l, "f");

--- a/src/strtest.cc
+++ b/src/strtest.cc
@@ -1,18 +1,130 @@
 #include "config.h"
 #include "mstring.h"
+#include <stdio.h>
+#include <libgen.h>
 
 char const *ApplicationName = "strtest";
 
-int main() {
-    ustring x("foo");
-    ustring n(0, 0);
+#define expect(u, s)    if (++testsrun, (u) == mstring(s) && 0 == strcmp(cstring(u).c_str(), s)) ++passed; else test_failed(u, s, __FILE__, __LINE__)
 
-    ustring y = x;
+#define assert(u, b)    if (++testsrun, (b)) ++passed; else test_failed(u, #b, __FILE__, __LINE__)
 
-    ustring z = y.remove(1, 1);
+static int testsrun, passed, failed;
+static const char *prog;
+
+static void test_failed(const mstring& u, const char *s, const char *f, int l)
+{
+    printf("%s: Test failed: %s.%d: u = \"%s\", s = \"%s\"\n",
+            prog, f, l, cstring(u).c_str(), s);
+    ++failed;
+}
+
+int main(int argc, char **argv)
+{
+    prog = basename(argv[0]);
+
+    mstring x("foo");
+    expect(x, "foo");
+    assert(x, x.length() == 3);
+
+    mstring b("bar", 2);
+    expect(b, "ba");
+    assert(b, b.length() == 2);
+
+    mstring e(null);
+    expect(e, "");
+    assert(e, e.length() == 0);
+
+    mstring m("abc", 0);
+    expect(m, "");
+    assert(m, m.length() == 0);
+
+    mstring n(0, 0);
+    expect(n, "");
+    assert(n, n.length() == 0);
+
+    mstring y = x;
+    expect(y, "foo");
+    assert(y, y.length() == 3);
+
+    mstring z = y.remove(1, 1);
+    expect(z, "fo");
+    assert(z, z.length() == 2);
+
+    e += b;
+    expect(e, "ba");
+    assert(e, e.length() == 2);
+
+    mstring c = y + e;
+    expect(c, "fooba");
+    assert(c, c.length() == 5);
+    assert(c, c != y);
+    assert(y, y != c);
+    assert(c, c != e);
+    assert(e, e != c);
+    assert(c, c != y);
+    assert(e, e != y);
+    assert(x, x == y);
+
+    mstring s = c.substring(2);
+    expect(s, "oba");
+    s = c.substring(2, 2);
+    expect(s, "ob");
+
+    assert(s, s.charAt(1) == 'b');
+    assert(s, s.charAt(2) == -1);
+    assert(s, s.indexOf('b') == 1);
+    assert(s, s.indexOf('c') == -1);
+
+    char buf[10];
+    c.copyTo(buf, sizeof buf);
+    expect(c, buf);
 
     for (int i = 0; i < 10000; i++) {
         z = x.replace(x.length(), 0, y);
+    }
+    expect(z, "foofoo");
+    assert(z, z.length() == 6);
+
+    assert(z, z.startsWith("foof"));
+    assert(z, !z.startsWith("goof"));
+    assert(z, !z.startsWith("foofoof"));
+    assert(z, z.startsWith(""));
+    assert(z, z.endsWith("foo"));
+    assert(z, !z.endsWith("foof"));
+    assert(z, !z.endsWith("foofoof"));
+    assert(z, z.endsWith(""));
+
+    mstring l(null), r(null);
+    assert(z, z.split('o', &l, &r));
+    expect(z, "foofoo");
+    expect(l, "f");
+    expect(r, "ofoo");
+    assert(l, l.splitall('o', &l, &r));
+    expect(l, "f");
+    expect(r, "");
+
+    mstring w = mstring(" \t\r\nabc\n\r\t ");
+    mstring t = w.trim();
+    expect(t, "abc");
+    assert(w, w == " \t\r\nabc\n\r\t ");
+    w = w.replace(0, 4, "_");
+    w = w.replace(4, 4, ".");
+    expect(w, "_abc.");
+    t = w.remove(1, 3);
+    expect(t, "_.");
+    mstring k = t.insert(1, "xyz");
+    expect(k, "_xyz.");
+    mstring q = t.append("!?");
+    expect(q, "_.!?");
+
+    if (failed || passed != testsrun) {
+        printf("%s: %d tests failed, %d tests passed of %d total\n",
+                prog, failed, passed, testsrun);
+    }
+    else {
+        printf("%s: %d/%d tests passed\n",
+                prog, passed, testsrun);
     }
     return 0;
 }

--- a/src/ystring.h
+++ b/src/ystring.h
@@ -45,7 +45,7 @@ public:
 
         if (size > fSize) {
             data_t * data(new data_t[size]);
-            ::memcpy(data, fData, fSize);
+            ::memcpy(data, fData, fSize * sizeof(data_t));
             ::memset(data + fSize, 0, (size - fSize - 1) * sizeof(data_t));
 
             delete[] fData;


### PR DESCRIPTION
    much more elaborate test suite for mstring.
    mstring cleanup to make it more readable and more easily verifiable correct.
    precondition simplification
    tTempBuf is not needed and not desirable
