### PR TITLE
Icehelp didn't draw the html list entries.

### DIFF
--- a/src/icehelp.cc
+++ b/src/icehelp.cc
@@ -551,7 +551,7 @@ public:
         contentsItem->setEnabled(false);
 
         if (nextURL != 0) {
-            delete[] prevURL;
+            delete[] nextURL;
             nextURL = 0;
         }
         if (nextURL != 0) {
@@ -759,14 +759,17 @@ void HTextView::find_link(node *n) {
             attribute *href = find_attribute(n, "HREF");
             if (rel && href && rel->value && href->value) {
                 if (strcasecmp(rel->value, "previous") == 0) {
+                    delete[] prevURL;
                     prevURL = newstr(href->value);
                     prevItem->setEnabled(true);
                 }
                 if (strcasecmp(rel->value, "next") == 0) {
+                    delete[] nextURL;
                     nextURL = newstr(href->value);
                     nextItem->setEnabled(true);
                 }
                 if (strcasecmp(rel->value, "contents") == 0) {
+                    delete[] contentsURL;
                     contentsURL = newstr(href->value);
                     contentsItem->setEnabled(true);
                 }
@@ -1167,6 +1170,8 @@ void HTextView::draw(Graphics &g, node *n1, bool href) {
 
         case node::li:
             g.fillArc(n->xr - tx, n->yr + (font->height() - 7) / 2 - ty, 7, 7, 0, 360 * 64);
+            if (n->container)
+                draw(g, n->container, href);
             break;
 
         default:
@@ -1233,8 +1238,8 @@ public:
 
         view->show();
 #else
-        free(fPath);
-        fPath = strdup(link);
+        delete[] fPath;
+        fPath = newstr(link);
         loadFile();
         view->repaint();
 #endif
@@ -1246,8 +1251,9 @@ public:
     }
 
     virtual void handleClose() {
+        IApp *tmp = app;
         delete this;
-        app->exit(0);
+        tmp->exit(0);
     }
 
 private:

--- a/src/yicon.cc
+++ b/src/yicon.cc
@@ -118,9 +118,9 @@ upath YIcon::findIcon(int size) {
             unsigned len(p - q);
             if (*p) ++p;
 
-            upath path = upath(newstr(q, len));
+            upath path(pstring(q, len));
 
-            upath fullpath = findIcon(path.path(), fPath, size);
+            upath fullpath = findIcon(path, fPath, size);
             if (fullpath != null) {
                 return fullpath;
             }
@@ -129,7 +129,7 @@ upath YIcon::findIcon(int size) {
 
     for (int i = 0; i < iconPaths->getCount(); i++) {
         upath path = iconPaths->getPath(i)->joinPath(upath("/icons/"));
-        upath fullpath = findIcon(path.path(), fPath, size);
+        upath fullpath = findIcon(path, fPath, size);
         if (fullpath != null)
             return fullpath;
     }


### PR DESCRIPTION
Fixed processing of node::li nodes by calling draw() to draw <LI>
entries.
There were several mismatches of new/delete/malloc/free: fixed.
Freed memory was accessed in handleClose(): fixed.
In YIcon::findIcon(int)  newstr was called for a temporary string
which was never going to be freed anywhere: fixed by using pstring
instead of newstr.