### PR TITLE
Use bash to run autogen.sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 cd "$(dirname "$0")"
 


### PR DESCRIPTION
I'm getting this error with your autogen.sh:
```
$ ./autogen.sh 
./autogen.sh: 13: ./autogen.sh: [[: not found
```

I'm on Ubuntu 16.04. `/bin/sh` on ubuntu points to [dash](https://wiki.ubuntu.com/DashAsBinSh). Just updating this to `env bash` solves the problem for me.