### PR TITLE
Use proper 'delete []' in place of 'delete'

### DIFF
--- a/src/amemstatus.cc
+++ b/src/amemstatus.cc
@@ -47,9 +47,11 @@ MEMStatus::MEMStatus(YWindow *aParent): YWindow(aParent) {
 
 MEMStatus::~MEMStatus() {
     for (int a(0); a < taskBarMEMSamples; a++) {
-        delete samples[a]; samples[a] = 0;
+        delete [] samples[a];
+        samples[a] = NULL;
     }
-    delete samples; samples = 0;
+    delete [] samples;
+    samples = NULL;
 }
 
 void MEMStatus::paint(Graphics &g, const YRect &/*r*/) {


### PR DESCRIPTION
This patch cleans up the freeing of memory by using the proper 'delete []' for objects that where created with a 'new []'.

