### PR TITLE
Stop 'psi' windows from warping on first move by title bar.

### DIFF
--- a/src/ywindow.cc
+++ b/src/ywindow.cc
@@ -777,10 +777,6 @@ void YWindow::handleConfigure(const XConfigureEvent &configure) {
 void YWindow::handleGravityNotify(const XGravityEvent& gravity) {
     if (gravity.window == handle()) {
         if (gravity.x != fX || gravity.y != fY) {
-            fX = gravity.x;
-            fY = gravity.y;
-
-            this->configure(geometry());
         }
     }
 }


### PR DESCRIPTION
This mostly reverts 03af26af5e880f4eee23545973061ccc2e363761

In 'psi' after opening a bookmarked 'chat' moving with the title bar would result in the widow warping to the left by 1/2 the screen or so.

As handleGravityNotify does not seem to be needed to update the location of windows I have disabled it.  This solves the issue with 'psi'.