### PR TITLE
Weird title bar colors in the default theme

### DIFF
--- a/lib/themes/default/default.theme
+++ b/lib/themes/default/default.theme
@@ -18,9 +18,9 @@ DlgBorderSizeX=2
 DlgBorderSizeY=2
 
 ColorNormalBorder="rgb:A0/A0/A0"
-ColorActiveBorder="rgb:D0/D0/D0"
-ColorActiveTitleBar="rgb:D0/D0/D0"
-ColorNormalTitleBar="rgb:A0/A0/A0"
+ColorActiveBorder="rgb:98/ab/d2"
+ColorActiveTitleBar="rgb:cf/cf/ff"
+ColorNormalTitleBar="rgb:cf/cf/cf"
 ColorNormalButton="rgb:C0/C0/C0"
 ColorNormalTitleBarText="rgb:00/00/00"
 ColorActiveTitleBarText="rgb:00/00/00"

--- a/lib/themes/default/default.theme
+++ b/lib/themes/default/default.theme
@@ -10,8 +10,8 @@ TitleButtonsLeft="sd"
 TitleButtonsRight="xmirh"
 TitleButtonsSupported="sxmihrd"
 
-BorderSizeX=6
-BorderSizeY=6
+BorderSizeX=5
+BorderSizeY=5
 CornerSizeX=16
 CornerSizeY=16
 DlgBorderSizeX=2


### PR DESCRIPTION
In the Default theme, the background color of buttons doesn't fit the title bar background color. I'm somewhat worried that this is a design choice, and then one can argue that it's subjective... but then I have to say that it's award enough to think that it's just some oversight. (I have also changed the border color, since the title bar background is now not gray.)