### PR TITLE
Make win95 menu button bg color match titlebar's

### DIFF
--- a/src/wmbutton.cc
+++ b/src/wmbutton.cc
@@ -215,11 +215,9 @@ void YFrameButton::paint(Graphics &g, const YRect &/*r*/) {
         }
     }
     else if (wmLook == lookWin95) {
-        g.fillRect(0, 0, width(), height());
         if (fAction == actionNull) {
-            if (!armed) {
-                g.setColor(background(focused()));
-            }
+            g.setColor(background(focused()));
+            g.fillRect(0, 0, width(), height());
             if (icon != null && showFrameIcon) {
                 icon->draw(g,
                            ((int) width() - iconSize) / 2,
@@ -227,6 +225,7 @@ void YFrameButton::paint(Graphics &g, const YRect &/*r*/) {
                            iconSize);
             }
         } else {
+            g.fillRect(0, 0, width(), height());
             g.drawBorderW(0, 0, width() - 1, height() - 1, !armed);
 
             if (armed)


### PR DESCRIPTION
The menu button icon in the top left corner of windows should have a bg color that matches the titlebar instead of one that matches the window frame.

Here is what it looks like in genuine win 95 and with this patch: https://www.betaarchive.com/imageupload/1240490523.th.26316.PNG
Here is what it looks like in icewm without the patch: https://i.imgur.com/ITwVYPx.jpg
