### PR TITLE
Don't waste taskbar space for window titles if there's no icon.

### DIFF
--- a/src/atasks.cc
+++ b/src/atasks.cc
@@ -180,7 +180,7 @@ void TaskBarApp::paint(Graphics &g, const YRect &/*r*/) {
     }
 
     ref<YIcon> icon(getFrame()->getIcon());
-    bool drew_icon = false;
+    bool drew_icon;
 
     if (taskBarShowWindowIcons && icon != null) {
         int iconSize = YIcon::smallSize();

--- a/src/atasks.cc
+++ b/src/atasks.cc
@@ -180,13 +180,14 @@ void TaskBarApp::paint(Graphics &g, const YRect &/*r*/) {
     }
 
     ref<YIcon> icon(getFrame()->getIcon());
+    bool drew_icon = false;
 
     if (taskBarShowWindowIcons && icon != null) {
         int iconSize = YIcon::smallSize();
 
         int const y((height() - 3 - iconSize -
                      ((wmLook == lookMetal) ? 1 : 0)) / 2);
-        icon->draw(g, p + 1, p + 1 + y, iconSize);
+        drew_icon = icon->draw(g, p + 1, p + 1 + y, iconSize);
     }
 
     ustring str = getFrame()->getIconTitle();
@@ -203,7 +204,7 @@ void TaskBarApp::paint(Graphics &g, const YRect &/*r*/) {
 
             int iconSize = 0;
             int pad = 1;
-            if (taskBarShowWindowIcons && icon != null) {
+            if (taskBarShowWindowIcons && drew_icon) {
                 iconSize = YIcon::smallSize();
                 pad = 3;
             }

--- a/src/yicon.cc
+++ b/src/yicon.cc
@@ -358,7 +358,7 @@ unsigned YIcon::hugeSize() {
     return hugeIconSize;
 }
 
-void YIcon::draw(Graphics &g, int x, int y, int size) {
+bool YIcon::draw(Graphics &g, int x, int y, int size) {
     ref<YImage> image = getScaledIcon(size);
     if (image != null) {
         if (!doubleBuffer) {
@@ -366,7 +366,9 @@ void YIcon::draw(Graphics &g, int x, int y, int size) {
         } else {
             g.compositeImage(image, 0, 0, size, size, x, y);
         }
+        return true;
     }
+    return false;
 }
 
 // vim: set sw=4 ts=4 et:

--- a/src/yicon.h
+++ b/src/yicon.h
@@ -25,7 +25,7 @@ public:
     static unsigned largeSize();
     static unsigned hugeSize();
 
-    void draw(Graphics &g, int x, int y, int size);
+    bool draw(Graphics &g, int x, int y, int size);
 
 private:
     ref<YImage> fSmall;


### PR DESCRIPTION
To have no icon, set the winoption icon to e.g. NULL (any non
existing path).  Useful if there are e.g. lots of xterms.

(This is a rewrite of https://sourceforge.net/p/icewm/patches/200/#bfc3 from 2011...)