### PR TITLE
Combine fixes for issue #232

### DIFF
--- a/src/default.h
+++ b/src/default.h
@@ -201,7 +201,7 @@ XSV(const char *, cpuClassHint,                 "top.XTerm")
 XIV(bool, cpuCombine,                           true)
 
 #ifdef __linux__
-XSV(const char *, netCommand,                   "xterm -name 'ss' -title 'Socket Statistics' -hold -e ss")
+XSV(const char *, netCommand,                   "xterm -name 'ss' -title 'Socket Statistics' -hold -e sh -c 'which ss > /dev/null && watch -t ss -putswl || netstat -c'")
 XSV(const char *, netClassHint,                 "ss.XTerm")
 #else
 XSV(const char *, netCommand,                   "xterm -name netstat -title 'Network Status' -hold -e netstat -c")


### PR DESCRIPTION
Contains @gijsbers fix for runonce and @Code7R command to roll ss as well as checking if ss exists (even on GNU/Linux systems, older systems will still have netstat and may not have ss)