### PR TITLE
Fix NetBSD APM includes

### DIFF
--- a/src/aapm.cc
+++ b/src/aapm.cc
@@ -34,7 +34,8 @@
 #include <sys/file.h>
 #include <sys/ioctl.h>
 #include <sys/types.h>
-#include <machine/apmvar.h>
+#include <dev/apm/apmbios.h>
+#include <dev/apm/apmio.h>
 #endif
 
 #include <math.h>

--- a/src/aapm.h
+++ b/src/aapm.h
@@ -1,5 +1,5 @@
 
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || (defined(__NetBSD__) && defined(i386)) || defined(__OpenBSD__)
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__) || defined(__OpenBSD__)
 
 #include "ywindow.h"
 #include "ytimer.h"


### PR DESCRIPTION
NetBSD/amd64 has no <machine/apm.h>, as APM is not a "native" concept
on amd64. However, the underlying header files from dev/apm, which do
exist and provide a compat wrapper, can be included directly.

This fixes compilation of `src/aapm.cc` on NetBSD/amd64 at least.

/cc @gijsbers 