### PR TITLE
Change the background for windows from other workspaces

### DIFF
--- a/src/atasks.cc
+++ b/src/atasks.cc
@@ -128,8 +128,8 @@ void TaskBarApp::paint(Graphics &g, const YRect &/*r*/) {
     } else if (!getFrame()->visibleNow()) {
         bg = invisibleTaskBarAppBg;
         fg = invisibleTaskBarAppFg;
-        bgPix = taskbackPixmap;
-        bgGrad = taskbackPixbuf;
+        bgPix = taskbuttonPixmap;
+        bgGrad = taskbuttonPixbuf;
     } else if (getFrame()->isMinimized()) {
         bg = minimizedTaskBarAppBg;
         fg = minimizedTaskBarAppFg;


### PR DESCRIPTION
Hello!
-------

I recently made a theme I like for IceWM and for the task background I did a simple colour but with 1px hill-bevels, and after opening a few windows I discovered that some of the task buttons had the taskbar button pixmap in them. It wouldn't have been a problem if these buttons just let the pixmap underneath show through, but as it is now it's just starting to draw the pixmap as it would do for the taskbar and as such it looks awkward, because only the top bevel can be seen; the pixmap is just the taskbar height and the buttons are smaller.

One solution I thought would be to add another file for example `taskbuttonhidden.xpm` that would only show for windows from other workspaces.
The easier and maybe a little bit more hackish would be to just display the normal button background.