### PR TITLE
Add `taskbuttoninvisible.xpm` to the _taskbar/_ config

### DIFF
--- a/src/atasks.cc
+++ b/src/atasks.cc
@@ -128,8 +128,12 @@ void TaskBarApp::paint(Graphics &g, const YRect &/*r*/) {
     } else if (!getFrame()->visibleNow()) {
         bg = invisibleTaskBarAppBg;
         fg = invisibleTaskBarAppFg;
-        bgPix = taskbackPixmap;
-        bgGrad = taskbackPixbuf;
+        bgPix = taskbuttoninvisiblePixmap;
+        bgLeft = taskbuttoninvisibleLeftPixmap;
+        bgRight = taskbuttoninvisibleRightPixmap;
+        bgGrad = taskbuttoninvisiblePixbuf;
+        bgLeftG = taskbuttoninvisibleLeftPixbuf;
+        bgRightG = taskbuttoninvisibleRightPixbuf;
     } else if (getFrame()->isMinimized()) {
         bg = minimizedTaskBarAppBg;
         fg = minimizedTaskBarAppFg;

--- a/src/wpixmaps.h
+++ b/src/wpixmaps.h
@@ -32,12 +32,15 @@ extern ref<YPixmap> menuButton[3];
 extern ref<YPixmap> taskbuttonPixmap;
 extern ref<YPixmap> taskbuttonactivePixmap;
 extern ref<YPixmap> taskbuttonminimizedPixmap;
+extern ref<YPixmap> taskbuttoninvisiblePixmap;
 extern ref<YPixmap> taskbuttonLeftPixmap;
 extern ref<YPixmap> taskbuttonRightPixmap;
 extern ref<YPixmap> taskbuttonactiveLeftPixmap;
 extern ref<YPixmap> taskbuttonactiveRightPixmap;
 extern ref<YPixmap> taskbuttonminimizedLeftPixmap;
 extern ref<YPixmap> taskbuttonminimizedRightPixmap;
+extern ref<YPixmap> taskbuttoninvisibleLeftPixmap;
+extern ref<YPixmap> taskbuttoninvisibleRightPixmap;
 
 extern ref<YPixmap> titleJ[2]; // Frame <=> Left buttons
 extern ref<YPixmap> titleL[2]; // Left buttons <=> Left pane
@@ -75,12 +78,15 @@ extern ref<YImage> taskbackPixbuf;
 extern ref<YImage> taskbuttonPixbuf;
 extern ref<YImage> taskbuttonactivePixbuf;
 extern ref<YImage> taskbuttonminimizedPixbuf;
+extern ref<YImage> taskbuttoninvisiblePixbuf;
 extern ref<YImage> taskbuttonLeftPixbuf;
 extern ref<YImage> taskbuttonRightPixbuf;
 extern ref<YImage> taskbuttonactiveLeftPixbuf;
 extern ref<YImage> taskbuttonactiveRightPixbuf;
 extern ref<YImage> taskbuttonminimizedLeftPixbuf;
 extern ref<YImage> taskbuttonminimizedRightPixbuf;
+extern ref<YImage> taskbuttoninvisibleLeftPixbuf;
+extern ref<YImage> taskbuttoninvisibleRightPixbuf;
 
 extern ref<YImage> toolbuttonPixbuf;
 

--- a/src/wpixres.cc
+++ b/src/wpixres.cc
@@ -261,6 +261,9 @@ static const PixmapResource taskbarPixRes[] = {
     PixmapResource(taskbuttonPixmap, "taskbuttonbg.xpm"),
     PixmapResource(taskbuttonactivePixmap, "taskbuttonactive.xpm"),
     PixmapResource(taskbuttonminimizedPixmap, "taskbuttonminimized.xpm"),
+
+    GradientResource(taskbuttoninvisiblePixbuf, "taskbuttoninvisible.xpm"),
+    PixmapResource(taskbuttoninvisiblePixmap, "taskbuttoninvisible.xpm"),
 };
 
 static const PixmapResource taskbar2PixRes[] = {
@@ -280,6 +283,9 @@ static const PixmapResource taskbar2PixRes[] = {
     PixmapResource(taskbarShowDesktopImage, "desktop.xpm"),
     PixmapResource(taskbarCollapseImage, "collapse.xpm"),
     PixmapResource(taskbarExpandImage, "expand.xpm"),
+
+    GradientResource(taskbuttoninvisiblePixbuf, "taskbuttoninvisible.xpm"),
+    PixmapResource(taskbuttoninvisiblePixmap, "taskbuttoninvisible.xpm"),
 };
 
 static const PixmapResource mailboxPixRes[] = {
@@ -521,6 +527,9 @@ static PixmapOffset taskbuttonPixmapOffsets[] = {
     PixmapOffset(taskbuttonminimizedPixmap,
                  taskbuttonminimizedLeftPixmap,
                  taskbuttonminimizedRightPixmap),
+    PixmapOffset(taskbuttoninvisiblePixmap,
+                 taskbuttoninvisibleLeftPixmap,
+                 taskbuttoninvisibleRightPixmap),
 };
 
 static PixbufOffset taskbuttonPixbufOffsets[] = {
@@ -533,6 +542,9 @@ static PixbufOffset taskbuttonPixbufOffsets[] = {
     PixbufOffset(taskbuttonminimizedPixbuf,
                  taskbuttonminimizedLeftPixbuf,
                  taskbuttonminimizedRightPixbuf),
+    PixbufOffset(taskbuttoninvisiblePixbuf,
+                 taskbuttoninvisibleLeftPixbuf,
+                 taskbuttoninvisibleRightPixbuf),
 };
 
 static void initPixmapOffsets() {


### PR DESCRIPTION
Add the `taskbuttoninvisible.xpm` image to represent the background for
windows from another workspace.