### PR TITLE
Convert tabs to spaces

### DIFF
--- a/lib/keys.in
+++ b/lib/keys.in
@@ -8,12 +8,12 @@
 # You'll have to omit XK_ prefixs and to replace XF86XK_ prefixes by
 # XF86. Valid modifiers are Alt, Ctrl, Shift, Meta, Super and Hyper.
 #
-key "Alt+Ctrl+t"			@XTERMCMD@
-key "Alt+Ctrl+b"			xdg-open about:blank
-key "Alt+Ctrl+s"			xdg-open https://www.google.com
+key "Alt+Ctrl+t"            @XTERMCMD@
+key "Alt+Ctrl+b"            xdg-open about:blank
+key "Alt+Ctrl+s"            xdg-open https://www.google.com
 
-key "Super+KP_Subtract"			amixer sset Master 5%-
-key "Super+KP_Add"			amixer sset Master 5%+
+key "Super+KP_Subtract"     amixer sset Master 5%-
+key "Super+KP_Add"          amixer sset Master 5%+
 
 # "Multimedia key" bindings for Xorg. Gather the keycodes of your
 # advanced function keys by watching the output of the xev command whilest
@@ -22,14 +22,14 @@ key "Super+KP_Add"			amixer sset Master 5%+
 # Note: some of them might have unwanted side effects through concurrency with
 # other listeners like systemd for the suspend key events
 #
-# key "XF86Standby"			/bin/sh -c "{ test -e /run/systemd/system && systemctl suspend; } ||:"
-# key "XF86Sleep"				/bin/sh -c "{ test -e /run/systemd/system && systemctl suspend; } ||:"
-key "XF86AudioLowerVolume"		amixer sset Master 5%-
-key "XF86AudioRaiseVolume"		amixer sset Master 5%+
-key "XF86AudioMute"			amixer sset Master toggle
-key "XF86HomePage"			xdg-open about:blank
-key "XF86Search"			xdg-open https://www.google.com
-key "XF86Eject"				eject
-key "XF86Calculator"			/bin/sh -c "gnome-calculator || xcalc || ( type bc >/dev/null 2>&1 && xterm -e bc -l)"
+# key "XF86Standby"         /bin/sh -c "{ test -e /run/systemd/system && systemctl suspend; } ||:"
+# key "XF86Sleep"           /bin/sh -c "{ test -e /run/systemd/system && systemctl suspend; } ||:"
+key "XF86AudioLowerVolume"  amixer sset Master 5%-
+key "XF86AudioRaiseVolume"  amixer sset Master 5%+
+key "XF86AudioMute"         amixer sset Master toggle
+key "XF86HomePage"          xdg-open about:blank
+key "XF86Search"            xdg-open https://www.google.com
+key "XF86Eject"             eject
+key "XF86Calculator"        /bin/sh -c "gnome-calculator || xcalc || ( type bc >/dev/null 2>&1 && xterm -e bc -l)"
 
-switchkey "Super+p"			icewm-menu-xrandr
+switchkey "Super+p"         icewm-menu-xrandr


### PR DESCRIPTION
Config files often patched and this will improve diff files and overall readability in various text editors. Please consider switch to space chars as a best practice nowadays.