### PR TITLE
Respond to right click on start button and friends

### DIFF
--- a/src/wmtaskbar.cc
+++ b/src/wmtaskbar.cc
@@ -387,6 +387,10 @@ void TaskBar::initApplets() {
     if (taskBarShowWindows) {
         fTasks = new TaskPane(this, this);
         fTasks->setTitle("TaskPane");
+        for(auto btn: {fApplications, fWinList, fShowDesktop}) {
+            if(btn)
+                btn->rerouteClickHandling(Button3, fTasks);
+        }
     } else
         fTasks = 0;
     if (taskBarShowTray) {

--- a/src/ybutton.cc
+++ b/src/ybutton.cc
@@ -287,6 +287,14 @@ void YButton::handleButton(const XButtonEvent &button) {
 }
 
 void YButton::handleClick(const XButtonEvent &button, int count) {
+    if(!vClickRedirects.empty()) {
+        for(auto& mapping: vClickRedirects) {
+            if(mapping.first == button.button) {
+                return mapping.second->handleClick(button, count);
+            }
+        }
+    }
+
     if (fEnabled && fPopup == 0) {
         bool wasArmed = fArmed;
 
@@ -296,6 +304,11 @@ void YButton::handleClick(const XButtonEvent &button, int count) {
             actionPerformed(fAction, button.state);
         }
     }
+}
+
+void YButton::rerouteClickHandling(unsigned buttonId, YWindow* replacementHandler)
+{
+    vClickRedirects.emplace_back(std::make_pair(buttonId, replacementHandler));
 }
 
 void YButton::handleCrossing(const XCrossingEvent &crossing) {

--- a/src/ybutton.h
+++ b/src/ybutton.h
@@ -3,6 +3,8 @@
 
 #include "ywindow.h"
 #include "yaction.h"
+#include <vector>
+#include <utility>
 
 class YMenu;
 class YIcon;
@@ -17,6 +19,7 @@ public:
     virtual bool handleKey(const XKeyEvent &key);
     virtual void handleButton(const XButtonEvent &button);
     virtual void handleClick(const XButtonEvent &button, int count);
+    void rerouteClickHandling(unsigned buttonId, YWindow* replacementHandler);
     virtual void handleCrossing(const XCrossingEvent &crossing);
 
     YAction getAction() const { return fAction; }
@@ -74,6 +77,7 @@ private:
     bool fEnabled;
     int fHotCharPos;
     int hotKey;
+    std::vector<std::pair<unsigned, YWindow*> > vClickRedirects;
 
     YActionListener *fListener;
 


### PR DESCRIPTION
Reroute the click events to the pane so it behaves just like if the user
would right-click on some unsed space of the taskbar.