### PR TITLE
Add a couple of undocumented keybinds

### DIFF
--- a/doc/icewm.adoc
+++ b/doc/icewm.adoc
@@ -385,6 +385,14 @@ which is navigable by the Up and Down keys. A rich set of editing
 operations is supported, including cut-/copy-/paste-operations and
 file completion using *Tab* or *Ctrl-I*.
 
+* `Ctrl+Alt+d`
++
+Show the desktop.
+
+* `Ctrl+Alt+h`
++
+Toggle taskbar visibility.
+
 [[the-resource-path]]
 == The Resource Path
 


### PR DESCRIPTION
The manual doesn't document the default Ctrl+Alt+d (show desktop) or Ctrl+Alt+h (collapse taskbar) keybinds, so this will add those in to the manual.  I wasn't sure about the wording for Ctrl+Alt+h; IMO "toggle taskbar visibility" makes the most sense, but since "collapse" is in the keybind name, I was thinking perhaps that should be in the docs, too?  Anyway, obviously feel free to change the wording on these.

Thanks!