### PR TITLE
improved grouped tab drawing routine

### DIFF
--- a/doc/icewm.adoc
+++ b/doc/icewm.adoc
@@ -685,6 +685,10 @@ Mouse wheel support.
 +
 Group applications with the same class name under a single task button.
 
+* `TaskBarGroupingStyle = 0`
++
+How to show how many grouped windows are under the tab. 0 - dots, 1 - digits.
+
 * `ShowPopupsAbovePointer = 0`
 +
 Show popup menus above mouse pointer.

--- a/src/atasks.cc
+++ b/src/atasks.cc
@@ -442,7 +442,7 @@ void TaskButton::paint(Graphics& g, const YRect& r) {
         if (crumbsBg == bg) crumbsBg = bg.darker();
     }
 
-    if (groupings) {
+    if (groupings && taskBarGroupingStyle == 0) {
         // crumbs for grouped tabs
         // drawing before text so that the text can overlap it for those who have really thin taskbar
         int crumbSize = 7;
@@ -488,7 +488,7 @@ void TaskButton::paint(Graphics& g, const YRect& r) {
                 textX = p + tx;
                 textY = p + ty;
                 int x = 0;
-                if (groupings) {
+                if (groupings && taskBarGroupingStyle == 1) {
                     mstring cnt = (mstring)groupCount;
                     int margins = 4;
                     x = font->textWidth(cnt, strlen(cnt)) + margins * 2;

--- a/src/default.h
+++ b/src/default.h
@@ -65,6 +65,7 @@ XIV(bool, taskBarWorkspacesTop,                 false)
 XSV(const char *, taskBarWorkspacesLimit,       0)
 XIV(bool, taskBarUseMouseWheel,                 true)
 XIV(bool, taskBarTaskGrouping,                  false)
+XIV(int,  taskBarGroupingStyle,                 0)
 XIV(bool, pagerShowPreview,                     true)
 XIV(bool, pagerShowWindowIcons,                 true)
 XIV(bool, pagerShowMinimized,                   true)
@@ -422,6 +423,7 @@ cfoption icewm_preferences[] = {
     OIV("NestedThemeMenuMinNumber",             &nestedThemeMenuMinNumber,  0, 1234,  "Minimal number of themes after which the Themes menu becomes nested (0=disabled)"),
     OIV("BatteryPollingPeriod",                 &batteryPollingPeriod, 2, 3600, "Delay between power status updates in seconds"),
     OIV("NetWorkAreaBehaviour",                 &netWorkAreaBehaviour, 0, 2,    "NET_WORKAREA behaviour: 0 (single/multimonitor with STRUT information, like metacity), 1 (always full desktop), 2 (singlemonitor with STRUT, multimonitor without STRUT)"),
+    OIV("TaskBarGroupingStyle",                 &taskBarGroupingStyle, 0, 1,    "How to show how many grouped windows are under the tab. (0=dots, 1=digits)"),
 ///    OSV("Theme",                                &themeName,                     "Theme name"),
     OSV("IconPath",                             &iconPath,                      "Icon search path (colon separated)"),
     OSV("IconThemes",                           &iconThemes,                    "Colon separated icon theme list with wildcard support. Minus prefix - can be used to exclude themes."),


### PR DESCRIPTION
Old one has issues with alignment/positioning, text did not fit with 10+ windows under one tab, black non configurable color looked out of theme. 

what I did:

- TaskBarGroupingStyle (0, 1)  - 0-default dots, 1-digits
- polished positioning of the digital counter to align perfectly with the icon and the text
- used `clrActiveTitleBar(Text)` for the digital counter
- used `bg.brighter()` for the dots
- carefully positioned dots at the bottom of the tab and behind text (if text overlaps for those who use really thin task bar)
- in case `brighter()` yields the same color as `bg` (this happens if bg was white) then `darker()` is used instead.

rationale for having dots by default is that users who would love digits are more likely to be friends with `preferences`.


![Selection_089](https://user-images.githubusercontent.com/3821217/112178099-185b0500-8c2c-11eb-8961-737169be1cf8.png)
![Selection_088](https://user-images.githubusercontent.com/3821217/112178114-1a24c880-8c2c-11eb-9dc3-136e810f5e2a.png)
