### PR TITLE
Fix building on a case-insensitive file system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,6 @@ include(CTest)
 
 set(PROJECT_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/src)
 include_directories(${CMAKE_BINARY_DIR})
-include_directories(${PROJECT_SOURCE_DIR})
 
 IF(NOT DEFINED(CMAKE_INSTALL_PREFIX))
 set(CMAKE_INSTALL_PREFIX "/usr/local" CACHE STRING "Target file space")


### PR DESCRIPTION
When compiling on a case-insensitive file system, adding the root
directory to the means that C++ headers including the stanard library
header <version> end up including the VERSION file in the root directory
instead. This include path does not appear to be not needed so we can
just drop it.