### PR TITLE
Fix switching to next/previous taskbar button

### DIFF
--- a/src/atasks.cc
+++ b/src/atasks.cc
@@ -1101,20 +1101,26 @@ void TaskPane::moveNext() {
 }
 
 void TaskPane::switchToPrev() {
-    TaskBarApp* act = getActiveApp();
-    if (act) {
-        TaskBarApp* pre = predecessor(act);
-        if (pre && pre != act)
-            pre->activate();
+    TaskButton* active = getActiveButton();
+    if (active) {
+        int index = find(fTasks, active);
+        if (index > 0)
+            --index;
+        else
+            index = fTasks.getCount() - 1;
+        fTasks[index]->activate();
     }
 }
 
 void TaskPane::switchToNext() {
-    TaskBarApp* act = getActiveApp();
-    if (act) {
-        TaskBarApp* suc = successor(act);
-        if (suc && suc != act)
-            suc->activate();
+    TaskButton* active = getActiveButton();
+    if (active) {
+        int index = find(fTasks, active);
+        if (index + 1 < fTasks.getCount())
+            ++index;
+        else
+            index = 0;
+        fTasks[index]->activate();
     }
 }
 


### PR DESCRIPTION
Fix switching to next/previous taskbar button via mouse wheel or KeyTaskBarSwitchNext / KeyTaskBarSwitchPrev.

Broken since 9f67e9545e0e81868a6bb9a5f444b01c6e32ba1b.
Fixes #602.