### PR TITLE
Fix OSS/ALSA defaults in icesound man page

### DIFF
--- a/man/icesound.pod
+++ b/man/icesound.pod
@@ -80,11 +80,11 @@ Please prefer one of the B<-A>, B<-O> or B<-S> options.
 
 =item B<-O>, B<--oss>=I<DEVICE>
 
-Specifies the OSS device (default: C<default>).
+Specifies the OSS device (default: F</dev/dsp>).
 
 =item B<-A>, B<--alsa>=I<DEVICE>
 
-Specifies the ALSA device (default: F</dev/dsp>).
+Specifies the ALSA device (default: C<default>).
 
 =item B<-z>, B<--snooze>=I<MILLISECONDS>
 


### PR DESCRIPTION
The default values given for the OSS and ALSA devices were switched around in the icesound man page. This PR corrects the man page to match the actual defaults: https://github.com/bbidulock/icewm/blob/3c490cf13bf8c2194f7f64d6c454a873ec29fcb3/src/icesound.cc#L86-L87

