### PR TITLE
Fix OSS/ALSA defaults in icesound help message

### DIFF
--- a/src/icesound.cc
+++ b/src/icesound.cc
@@ -733,7 +733,7 @@ Return values:\n\
   2    Command line error.\n\
   3    Subsystems error (ie cannot connect to server).\n\n"),
            ApplicationName, audio_interfaces, audio_interfaces,
-           ALSA_DEFAULT_DEVICE, OSS_DEFAULT_DEVICE);
+           OSS_DEFAULT_DEVICE, ALSA_DEFAULT_DEVICE);
 
     ::exit(0);
 }


### PR DESCRIPTION
Oops, I noticed that the mixup I fixed in the man page is also present in the help message. I wasn't quick enough to update the PR before you merged it. Sorry.