### PR TITLE
Feature/ignore thermal zones

### DIFF
--- a/doc/icewm.adoc
+++ b/doc/icewm.adoc
@@ -1039,7 +1039,14 @@ Show ACPI temperature in CPU status tool tip.
 Show ACPI temperature in CPU graph.
 
 * `AcpiIgnoreBatteries =`
-List of battery names ignore.
++
+List of battery names to ignore.
+
+* `IgnoreThermalZones =`
++
+List of thermal zone types, from /sys/class/thermal_zoneX/type to ignore.
+Useful when some thermal zones block for too long when the temp is read.
+
 * `CPUStatusShowCpuFreq = 1`
 +
 Show CPU frequency in CPU status tool tip.

--- a/man/icewm-preferences.pod
+++ b/man/icewm-preferences.pod
@@ -689,6 +689,11 @@ Screen/output name of the primary screen.
 List of battery names (directories) in /proc/acpi/battery to ignore.
 Useful when more slots are built-in, but only one battery is used.
 
+=item B<IgnoreThermalZones>=""
+
+List of thermal zone types, from /sys/class/thermal_zoneX/type to ignore.
+Useful when some thermal zones block for too long when the temp is read.
+
 =item B<TaskBarCPUSamples>=20  [2-1000]
 
 The width of the CPU Monitor applet in pixels.

--- a/src/acpustatus.cc
+++ b/src/acpustatus.cc
@@ -431,6 +431,22 @@ int CPUStatus::getAcpiTemp(char *tempbuf, int buflen) {
             if (strncmp(dir.entry(), "thermal", 7))
                 continue;
 
+            if (ignoreThermalZones) {
+                snprintf(namebuf, sizeof namebuf,
+                        "/sys/class/thermal/%s/type", dir.entry());
+                auto len = filereader(namebuf).read_all(BUFNSIZE(buf));
+                if (len > 0) {
+                    // Trim newline, if it exists.
+                    if (buf[len - 1] == '\n') {
+                        buf[len - 1] = '\0';
+                    }
+
+                    if (strstr(ignoreThermalZones, buf)) {
+                        continue;
+                    }
+                }
+            }
+
             snprintf(namebuf, sizeof namebuf,
                     "/sys/class/thermal/%s/temp", dir.entry());
             auto len = filereader(namebuf).read_all(BUFNSIZE(buf));

--- a/src/acpustatus.cc
+++ b/src/acpustatus.cc
@@ -253,18 +253,17 @@ void CPUStatus::draw(Graphics& g) {
 
 void CPUStatus::temperature(Graphics& g) {
     if (cpustatusShowAcpiTempInGraph) {
-        char temp[10];
-        getAcpiTemp(temp, sizeof(temp));
+        char temp[50];
+        int len = getAcpiTemp(temp, sizeof(temp));
         g.setColor(fTempColor);
         if (tempFont == null)
             tempFont = tempFontName;
         if (tempFont) {
             g.setFont(tempFont);
-            int h = height();
-            int y = (h - 1 - tempFont->height()) / 2 + tempFont->ascent();
+            int y = (height() - tempFont->height()) / 2 + tempFont->ascent();
             int w = tempFont->textWidth(temp);
             int x = max(0, (int(g.rwidth()) - w) / 2);
-            g.drawChars(temp, 0, 3, x, y);
+            g.drawChars(temp, 0, len, x, y);
         }
     }
 }

--- a/src/default.h
+++ b/src/default.h
@@ -175,6 +175,7 @@ XIV(int, batteryPollingPeriod,                  10)
 XIV(int, netWorkAreaBehaviour,                  0)
 
 XSV(const char *, acpiIgnoreBatteries,          0)
+XSV(const char *, ignoreThermalZones,           0)
 XSV(const char *, mailBoxPath,                  0)
 XSV(const char *, mailCommand,                  TERM " -name mutt -e mutt")
 XSV(const char *, mailClassHint,                "mutt.XTerm")
@@ -461,6 +462,7 @@ cfoption icewm_preferences[] = {
     OSV("DockApps",                             &dockApps,                       "Support DockApps (right, left, center, down, high, above, below, desktop, or empty to disable). Control with Ctrl+Mouse."),
     OSV("XRRPrimaryScreenName",                 &xineramaPrimaryScreenName,     "screen/output name of the primary screen"),
     OSV("AcpiIgnoreBatteries",                  &acpiIgnoreBatteries,           "List of battery names (directories) in /proc/acpi/battery to ignore. Useful when more slots are built-in, but only one battery is used"),
+    OSV("IgnoreThermalZones",                   &ignoreThermalZones,            "List of thermal zone types, from /sys/class/thermal/thermal_zoneX/type, to ignore. Useful when some temp reads block for too long, e.g. iwlwifi"),
 
     OKV("MouseWinMove",                         gMouseWinMove,                  "Mouse binding for window move"),
     OKV("MouseWinSize",                         gMouseWinSize,                  "Mouse binding for window resize"),


### PR DESCRIPTION
Some thermal zones' temperatures take a long time to read (e.g. 0.5 seconds). When ACPI temperatures are displayed in the CPU graph, these temperatures are polled repeatedly, and any blockage, blocks the entire window manager. This change adds an option, IgnoreThermalZones, which allows any such offending thermal zones to be skipped and not slow down the window manager.

Also, I changed the temperature display in the CPU graph to display all (non-ignored) ACPI temps. Let me know if you think this should be adaptive based on the width of the CPU monitor (with a low-width CPU monitor, they won't fit), or configurable in some way.