### PR TITLE
Feature/ignore iwlwifi thermal (for CPU Status temperatures in graph)

### DIFF
--- a/src/acpustatus.cc
+++ b/src/acpustatus.cc
@@ -279,6 +279,11 @@ void CPUStatus::temperature(Graphics& g) {
     int filllen = min(int(sizeof(temp)), n_chars + 1);
 
     int len = getAcpiTemp(temp, filllen, false);
+
+    if (len <= 0) {
+        return;
+    }
+
     int y = (height() - tempFont->height()) / 2 + tempFont->ascent();
     int x = max(0, (int(g.rwidth()) - len * sw) / 2);
 
@@ -439,20 +444,15 @@ signed char CPUStatus::tzPriority(const char *tz_type) {
     // tz_type must be a null terminated string.
     // High numbers are preferred.
     // Negative numbers are excluded.
-    if (strstr(tz_type, "iwlwifi")) {
+    if (!strncmp(tz_type, "iwlwifi", 7)) {
         return -1;
     }
 
-    if (strstr(tz_type, "x86_pkg_temp")) {
-        return 3;
-    }
-
-    if (!strncmp(tz_type, "pch_", 4)) {
-        return 2;
-    }
-
-    if (strstr(tz_type, "acpitz")) {
-        return 1;
+    const char* tzs[] = { "x86_pkg_temp", "pch_", "acpitz" };
+    for (int i = 0; i < 3; i++) {
+        if (!strncmp(tz_type, tzs[i], strlen(tzs[i]))) {
+            return 3 - i;
+        }
     }
 
     return 0;

--- a/src/acpustatus.cc
+++ b/src/acpustatus.cc
@@ -253,18 +253,17 @@ void CPUStatus::draw(Graphics& g) {
 
 void CPUStatus::temperature(Graphics& g) {
     if (cpustatusShowAcpiTempInGraph) {
-        char temp[10];
-        getAcpiTemp(temp, sizeof(temp));
+        char temp[50];
+        int len = getAcpiTemp(temp, sizeof(temp));
         g.setColor(fTempColor);
         if (tempFont == null)
             tempFont = tempFontName;
         if (tempFont) {
             g.setFont(tempFont);
-            int h = height();
-            int y = (h - 1 - tempFont->height()) / 2 + tempFont->ascent();
+            int y = (height() - tempFont->height()) / 2 + tempFont->ascent();
             int w = tempFont->textWidth(temp);
             int x = max(0, (int(g.rwidth()) - w) / 2);
-            g.drawChars(temp, 0, 3, x, y);
+            g.drawChars(temp, 0, len, x, y);
         }
     }
 }

--- a/src/acpustatus.h
+++ b/src/acpustatus.h
@@ -36,7 +36,6 @@ public:
     void updateStatus();
     void getStatus();
     void getStatusPlatform();
-    int getAcpiTemp(char* tempbuf, int buflen, bool longform);
     float getCpuFreq(int cpu);
     int getCpuID() const { return fCpuID; }
     virtual void updateToolTip();
@@ -57,6 +56,8 @@ private:
     void fill(Graphics& g);
     void draw(Graphics& g);
     void temperature(Graphics& g);
+    signed char tzPriority(const char* tz);
+    int getAcpiTemp(char* tempbuf, int buflen, bool longform);
 
     static YFont tempFont;
 };

--- a/src/acpustatus.h
+++ b/src/acpustatus.h
@@ -36,7 +36,7 @@ public:
     void updateStatus();
     void getStatus();
     void getStatusPlatform();
-    int getAcpiTemp(char* tempbuf, int buflen);
+    int getAcpiTemp(char* tempbuf, int buflen, bool longform);
     float getCpuFreq(int cpu);
     int getCpuID() const { return fCpuID; }
     virtual void updateToolTip();


### PR DESCRIPTION
Ignore the `iwlwifi` thermal zone, since it takes too long to read.

Also center the temperatures in the graph according to its width.