### PR TITLE
Add "Hibernate" option, add a possible workaround for nosystemd systems

### DIFF
--- a/man/icewm-preferences.pod
+++ b/man/icewm-preferences.pod
@@ -1032,15 +1032,19 @@ Command to start logout.
 
 Command to cancel logout.
 
-=item B<ShutdownCommand>="/bin/sh -c "{ test -e /run/systemd/system && systemctl poweroff; } ||:""
+=item B<ShutdownCommand>="/bin/sh -c "{ test -e /run/systemd/system && systemctl poweroff || loginctl poweroff; } ||:""
 
 Command to shutdown the system.
 
-=item B<RebootCommand>="/bin/sh -c "{ test -e /run/systemd/system && systemctl reboot; } ||:""
+=item B<RebootCommand>="/bin/sh -c "{ test -e /run/systemd/system && systemctl reboot || loginctl reboot; } ||:""
 
 Command to reboot the system.
 
-=item B<SuspendCommand>="test -e /run/systemd/system && systemctl suspend"
+=item B<SuspendCommand>="test -e /run/systemd/system && systemctl suspend || loginctl suspend"
+
+Command to hibernate the system.
+
+=item B<SuspendCommand>="test -e /run/systemd/system && systemctl suspend || loginctl suspend"
 
 Command to send the system to standby mode
 

--- a/src/default.h
+++ b/src/default.h
@@ -188,13 +188,15 @@ XSV(const char *, terminalCommand,              TERM " -hold")
 XSV(const char *, logoutCommand,                0)
 XSV(const char *, logoutCancelCommand,          0)
 #if __linux__
-XSV(const char *, shutdownCommand,              "test -e /run/systemd/system && systemctl poweroff")
-XSV(const char *, rebootCommand,                "test -e /run/systemd/system && systemctl reboot")
-XSV(const char *, suspendCommand,               "test -e /run/systemd/system && systemctl suspend")
+XSV(const char *, shutdownCommand,              "test -e /run/systemd/system && systemctl poweroff || loginctl poweroff")
+XSV(const char *, rebootCommand,                "test -e /run/systemd/system && systemctl reboot || loginctl reboot")
+XSV(const char *, suspendCommand,               "test -e /run/systemd/system && systemctl suspend || loginctl suspend")
+XSV(const char *, hibernateCommand,             "test -e /run/systemd/system && systemctl hibernate || loginctl suspend")
 #else
 XSV(const char *, shutdownCommand,              0)
 XSV(const char *, rebootCommand,                0)
 XSV(const char *, suspendCommand,               0)
+XSV(const char *, hibernateCommand,             0)
 #endif
 XIV(int, taskBarCPUDelay,                       500)
 XIV(int, taskBarMEMDelay,                       500)
@@ -449,6 +451,7 @@ cfoption icewm_preferences[] = {
     OSV("ShutdownCommand",                      &shutdownCommand,               "Command to shutdown the system"),
     OSV("RebootCommand",                        &rebootCommand,                 "Command to reboot the system"),
     OSV("SuspendCommand",                       &suspendCommand,                "Command to send the system to standby mode"),
+    OSV("HibernateCommand",                     &hibernateCommand,              "Command to hibernate the system"),
     OSV("CPUStatusCommand",                     &cpuCommand,                    "Command to run on CPU status"),
     OSV("CPUStatusClassHint",                   &cpuClassHint,                  "WM_CLASS to allow runonce for CPUStatusCommand"),
     OBV("CPUStatusCombine",                     &cpuCombine,                    "Combine all CPUs to one"),

--- a/src/icesh.cc
+++ b/src/icesh.cc
@@ -2807,6 +2807,7 @@ bool IceSh::icewmAction()
         { "windowlist", ICEWM_ACTION_WINDOWLIST },
         { "restart",    ICEWM_ACTION_RESTARTWM },
         { "suspend",    ICEWM_ACTION_SUSPEND },
+        { "hibernate",  ICEWM_ACTION_HIBERNATE },
         { "winoptions", ICEWM_ACTION_WINOPTIONS },
         { "keys",       ICEWM_ACTION_RELOADKEYS },
         { "icewmbg",    ICEWM_ACTION_ICEWMBG },
@@ -2851,7 +2852,7 @@ unsigned IceSh::count() const
 {
     return windowList.count();
 }
-
+ 
 /******************************************************************************/
 
 static void setLayer(Window window, long layer) {

--- a/src/icesh.cc
+++ b/src/icesh.cc
@@ -2852,7 +2852,7 @@ unsigned IceSh::count() const
 {
     return windowList.count();
 }
- 
+
 /******************************************************************************/
 
 static void setLayer(Window window, long layer) {

--- a/src/wmaction.h
+++ b/src/wmaction.h
@@ -14,10 +14,11 @@ enum WMAction {
     ICEWM_ACTION_WINDOWLIST = 7,
     ICEWM_ACTION_RESTARTWM = 8,
     ICEWM_ACTION_SUSPEND = 9,
-    ICEWM_ACTION_WINOPTIONS = 10,
-    ICEWM_ACTION_RELOADKEYS = 11,
-    ICEWM_ACTION_ICEWMBG = 12,
-    ICEWM_ACTION_REFRESH = 13,
+    ICEWM_ACTION_HIBERNATE = 10,
+    ICEWM_ACTION_WINOPTIONS = 11,
+    ICEWM_ACTION_RELOADKEYS = 12,
+    ICEWM_ACTION_ICEWMBG = 13,
+    ICEWM_ACTION_REFRESH = 14,
 };
 
 enum RebootShutdown {
@@ -70,6 +71,7 @@ enum EAction {
     actionRestartXterm       = 169,
     actionShutdown           = 171,
     actionSuspend            = 173,
+    actionHibernate          = 174,
     actionRefresh            = 175,
     actionAbout              = 177,
     actionRun                = 179,
@@ -126,6 +128,7 @@ enum EAction {
 
 bool canShutdown(RebootShutdown reboot);
 bool canSuspend();
+bool canHibernate();
 bool canLock();
 /**
  * Basic check whether a shell command could possibly be run.

--- a/src/wmaction.h
+++ b/src/wmaction.h
@@ -14,11 +14,11 @@ enum WMAction {
     ICEWM_ACTION_WINDOWLIST = 7,
     ICEWM_ACTION_RESTARTWM = 8,
     ICEWM_ACTION_SUSPEND = 9,
-    ICEWM_ACTION_HIBERNATE = 10,
-    ICEWM_ACTION_WINOPTIONS = 11,
-    ICEWM_ACTION_RELOADKEYS = 12,
-    ICEWM_ACTION_ICEWMBG = 13,
-    ICEWM_ACTION_REFRESH = 14,
+    ICEWM_ACTION_WINOPTIONS = 10,
+    ICEWM_ACTION_RELOADKEYS = 11,
+    ICEWM_ACTION_ICEWMBG = 12,
+    ICEWM_ACTION_REFRESH = 13,
+    ICEWM_ACTION_HIBERNATE = 14,
 };
 
 enum RebootShutdown {
@@ -123,6 +123,7 @@ enum EAction {
     actionRename             = 257,
     actionSysDialog          = 259,
     actionIcewmbg            = 261,
+    actionHibernate          = 263,
 };
 
 bool canShutdown(RebootShutdown reboot);

--- a/src/wmaction.h
+++ b/src/wmaction.h
@@ -71,7 +71,6 @@ enum EAction {
     actionRestartXterm       = 169,
     actionShutdown           = 171,
     actionSuspend            = 173,
-    actionHibernate          = 174,
     actionRefresh            = 175,
     actionAbout              = 177,
     actionRun                = 179,

--- a/src/wmapp.cc
+++ b/src/wmapp.cc
@@ -524,7 +524,8 @@ void LogoutMenu::updatePopup() {
                 addItem(_("Shut_down"), -2, null, actionShutdown, "shutdown");
             if (canSuspend())
                 addItem(_("_Sleep mode"), -2, null, actionSuspend, "suspend");
-
+            if (canHibernate())
+                addItem(_("_Hibernate"), -2, null, actionHibernate, "hibernate");
             if (itemCount() != oldItemCount)
                 addSeparator();
 
@@ -945,6 +946,8 @@ void YWMApp::actionPerformed(YAction action, unsigned int /*modifiers*/) {
         doLogout(Shutdown);
     } else if (action == actionSuspend) {
         runCommand(suspendCommand);
+    } else if (action == actionHibernate) {
+        runCommand(hibernateCommand);
     } else if (action == actionReboot) {
         doLogout(Reboot);
     } else if (action == actionRestart) {
@@ -1980,6 +1983,7 @@ void YWMApp::handleSMAction(WMAction message) {
         { ICEWM_ACTION_WINDOWLIST,    actionWindowList },
         { ICEWM_ACTION_RESTARTWM,     actionRestart },
         { ICEWM_ACTION_SUSPEND,       actionSuspend },
+        { ICEWM_ACTION_HIBERNATE,     actionHibernate },
         { ICEWM_ACTION_WINOPTIONS,    actionWinOptions },
         { ICEWM_ACTION_RELOADKEYS,    actionReloadKeys },
         { ICEWM_ACTION_ICEWMBG,       actionIcewmbg },

--- a/src/wmdialog.cc
+++ b/src/wmdialog.cc
@@ -48,6 +48,10 @@ bool canSuspend() {
     return couldRunCommand(suspendCommand);
 }
 
+bool canHibernate() {
+    return couldRunCommand(hibernateCommand);
+}
+
 bool canShutdown(RebootShutdown reboot) {
     if (reboot == Shutdown && isEmpty(shutdownCommand))
         return false;
@@ -84,6 +88,7 @@ CtrlAltDelete::CtrlAltDelete(IApp* app, YWindow* parent)
         { _("_Logout..."), actionLogout, ICEWM_ACTION_LOGOUT },
         { _("Re_boot"), actionReboot, ICEWM_ACTION_REBOOT },
         { _("Shut_down"), actionShutdown, ICEWM_ACTION_SHUTDOWN },
+        { _("Hibernate"), actionHibernate, ICEWM_ACTION_HIBERNATE },
         { _("_Window list"), actionWindowList, ICEWM_ACTION_WINDOWLIST },
         { _("_Restart icewm"), actionRestart, ICEWM_ACTION_RESTARTWM },
         { _("_About"), actionAbout, ICEWM_ACTION_ABOUT },
@@ -108,6 +113,8 @@ CtrlAltDelete::CtrlAltDelete(IApp* app, YWindow* parent)
         buttons[4]->setEnabled(false);
     if (!canShutdown(Shutdown))
         buttons[5]->setEnabled(false);
+    if (!canHibernate())
+        buttons[6]->setEnabled(false);
 
     setSize(HORZ + w + MIDH + w + MIDH + w + HORZ,
             VERT + (h + MIDV) * (Count / 3) - MIDV + VERT);

--- a/src/wmdialog.h
+++ b/src/wmdialog.h
@@ -26,7 +26,7 @@ private:
     int indexFocus();
 
     IApp *app;
-    enum { Count = 12, };
+    enum { Count = 13, };
     YActionButton* buttons[Count];
 };
 

--- a/src/wmmgr.cc
+++ b/src/wmmgr.cc
@@ -946,6 +946,7 @@ void YWindowManager::handleClientMessage(const XClientMessageEvent &message) {
         case ICEWM_ACTION_CANCEL_LOGOUT:
         case ICEWM_ACTION_SHUTDOWN:
         case ICEWM_ACTION_SUSPEND:
+        case ICEWM_ACTION_HIBERNATE:
         case ICEWM_ACTION_REBOOT:
         case ICEWM_ACTION_RESTARTWM:
         case ICEWM_ACTION_WINDOWLIST:


### PR DESCRIPTION
# Add "Hibernate" Option
 - Useful for those who want to hibernate their system with the icewm menu itself
 - Added option in prefs, wmdialog and menu

# Add a workaround for nosystemd systems
- Simply added ```|| loginctl ... ``` at the end of all session commands
 
 # Summary
 Changes to be committed:
	modified:   man/icewm-preferences.pod
	modified:   src/default.h
	modified:   src/icesh.cc
	modified:   src/wmaction.h
	modified:   src/wmapp.cc
	modified:   src/wmdialog.cc
	modified:   src/wmdialog.h
	modified:   src/wmmgr.cc