### PR TITLE
Partial fix for button grab persisting after window is focused

### DIFF
--- a/src/wmframe.cc
+++ b/src/wmframe.cc
@@ -1958,7 +1958,7 @@ void YFrameWindow::setWinFocus() {
         }
         updateTaskBar();
 
-        if (!raiseOnClickClient || !canRaise() || !overlapped())
+        if (!raiseOnClickClient || raiseOnFocus || !canRaise() || !overlapped())
             container()->releaseButtons();
         if (taskBar) {
             taskBar->workspacesRepaint(getWorkspace());


### PR DESCRIPTION
Related to issue #742: Strange Firefox Behavior in IceWM.

Currently icewm seems to retain grab on mouse buttons after switching focus between windows. In some Firefox and Chrome versions this causes problems with hover elements on webpages.

The root cause seems to be that the data used by canRaise() and overlapped() functions is only updated after YFrameWindow::setWinFocus() has already checked their value.

This commit works around the problem in common configuration where raiseOnFocus setting is enabled.
In that case, we know that the focused window will eventually be raised and it is unnecessary to retain the button grab.

The issue still remains in configurations where raiseOnClickClient=1 and raiseOnFocus=0.