### PR TITLE
lower focus on lowered windows

### DIFF
--- a/src/wmframe.cc
+++ b/src/wmframe.cc
@@ -1750,6 +1750,7 @@ void YFrameWindow::wmLower() {
             doLower();
         }
         manager->focusTopWindow();
+        manager->lowerFocusFrame(this);
     }
 }
 


### PR DESCRIPTION
After pressing alt+f3 to fully lower a window, the focus window list still keeps that window second, so alt+tab returns to the lowered window.
This patch moved the lowered window to the bottom of the focus list (which is the behavior in my older icewm 1.3.<something>...).
