### PR TITLE
Update window title with `(on <client_machine>)` if client is remote

### DIFF
--- a/src/wmtitle.cc
+++ b/src/wmtitle.cc
@@ -526,6 +526,11 @@ void YFrameTitleBar::paint(Graphics &g, const YRect &/*r*/) {
     }
 
     mstring title = getFrame()->getTitle();
+    char *client_machine = getFrame()->client()->fetchClientMachine();
+    if (strncmp(client_machine, xapp->getLocalHostname(), strlen(client_machine)) != 0)
+        title = title + "  (on " + client_machine + ")";
+    free(client_machine);
+
     int const fontHeight = titleFont ? titleFont->height() : 8;
     int const fontAscent = titleFont ? titleFont->ascent() : 6;
     int const yPos(int(height() - fontHeight) / 2 +

--- a/src/wmtitle.cc
+++ b/src/wmtitle.cc
@@ -527,9 +527,10 @@ void YFrameTitleBar::paint(Graphics &g, const YRect &/*r*/) {
 
     mstring title = getFrame()->getTitle();
     char *client_machine = getFrame()->client()->fetchClientMachine();
-    if (strncmp(client_machine, xapp->getLocalHostname(), strlen(client_machine)) != 0)
+    if (client_machine != nullptr && strncmp(client_machine, xapp->getLocalHostname(), strlen(client_machine)) != 0) {
         title = title + "  (on " + client_machine + ")";
-    free(client_machine);
+        free(client_machine);
+    }
 
     int const fontHeight = titleFont ? titleFont->height() : 8;
     int const fontAscent = titleFont ? titleFont->ascent() : 6;

--- a/src/ywindow.cc
+++ b/src/ywindow.cc
@@ -196,6 +196,18 @@ bool YWindow::fetchTitle(char** title) {
     return XFetchName(xapp->display(), handle(), title);
 }
 
+char* YWindow::fetchClientMachine() {
+    XTextProperty prop;
+    int ret = XGetTextProperty(xapp->display(), handle(), &prop, XA_WM_CLIENT_MACHINE);
+    if (ret) {
+        char *retval = (char *)malloc(sizeof(char)*prop.nitems + 1);
+        strncpy(retval, (const char *)prop.value, prop.nitems + 1);
+        XFree(prop.value);
+        return retval;
+    }
+        return nullptr;
+}
+
 void YWindow::setClassHint(char const * rName, char const * rClass) {
     XClassHint wmclass;
     wmclass.res_name = const_cast<char *>(rName);

--- a/src/ywindow.h
+++ b/src/ywindow.h
@@ -98,6 +98,7 @@ public:
     void setWindowFocus(Time timestamp = CurrentTime);
 
     bool fetchTitle(char** title);
+    char* fetchClientMachine();
     void setTitle(char const * title);
     void setClassHint(char const * rName, char const * rClass);
 

--- a/src/yxapp.h
+++ b/src/yxapp.h
@@ -5,6 +5,7 @@
 #include "ywindow.h"
 #include "ycursor.h"
 #include <X11/Xutil.h>
+#include <unistd.h>
 
 #define KEY_MODMASK(x) ((x) & (xapp->KeyMask))
 
@@ -101,6 +102,16 @@ class YXApplication: public YApplication {
 public:
     YXApplication(int *argc, char ***argv, const char *displayName = nullptr);
     virtual ~YXApplication();
+
+    char localHostname[256] = {};
+    char * getLocalHostname() {
+        if (localHostname[0] == 0) {
+            gethostname(localHostname, sizeof(localHostname));
+        }
+
+        return localHostname;
+    }
+
 
     Display * display()   const { return fDisplay; }
     int screen()          const { return fScreen; }


### PR DESCRIPTION
This pull request introduces changes to display the client machine's hostname in the window title if it differs from the local machine's hostname. The most important changes include adding methods to fetch the client machine's hostname and updating the window title rendering logic.

Sample screenshot of Xephyr with a remote Google Chrome:
![image](https://github.com/user-attachments/assets/1eb6aca2-294e-4b9c-bcdd-e1f61d6d1b79)

Enhancements to window title display:

* [`src/wmtitle.cc`](diffhunk://#diff-ef2a6858822b7527269bb7555625dd5b2d02b3d3a2e2e6dd1eb4768342832159R529-R533): Updated `YFrameTitleBar::paint` method to append the client machine's hostname to the window title if it is different from the local machine's hostname.

New methods for fetching client machine information:

* [`src/ywindow.cc`](diffhunk://#diff-e332ccde7a5f317492863a8a1f95150c5ffead2fee57e7c7d567da8098fde3ecR199-R210): Added `YWindow::fetchClientMachine` method to retrieve the client machine's hostname using `XGetTextProperty`.
* [`src/ywindow.h`](diffhunk://#diff-d539f01ecbaf8a2a9aca3041963e141f8cf2979cbbafa03d5b2a13a4f6f3938aR101): Declared the new `fetchClientMachine` method in the `YWindow` class.

Local hostname retrieval:

* [`src/yxapp.h`](diffhunk://#diff-cc11cc3dc6d942077411d8ff833fd41ae19bcede76a8bf1fa75451685d9adb49R8): Included `<unistd.h>` for `gethostname` function and added `localHostname` member and `getLocalHostname` method to `YXApplication` class to retrieve and cache the local machine's hostname. [[1]](diffhunk://#diff-cc11cc3dc6d942077411d8ff833fd41ae19bcede76a8bf1fa75451685d9adb49R8) [[2]](diffhunk://#diff-cc11cc3dc6d942077411d8ff833fd41ae19bcede76a8bf1fa75451685d9adb49R106-R115)