### PR TITLE
Don't move the frame offscreen for static windows with 0,0

### DIFF
--- a/src/wmmgr.cc
+++ b/src/wmmgr.cc
@@ -1724,10 +1724,6 @@ void YWindowManager::placeWindow(YFrameWindow *frame,
             posX -= 2 * borderWidth - client->getBorder() - 1;
         if (gy > 0)
             posY -= 2 * borderHeight + titleHeight - client->getBorder() - 1;
-        if (gx == 0 && gy == 0 && client->winGravity() == StaticGravity) {
-            posX -= borderWidth;
-            posY -= borderHeight + titleHeight;
-        }
         posY -= borderOffset;
     }
 


### PR DESCRIPTION
Some clients like Qt 6.10 sends a static position to the top left corner. Moving the position above that causes the title and border to be placed out of screen.

See also: https://bugreports.qt.io/browse/QTBUG-141099