### PR TITLE
Ensure the window is within the screen even if positioned

### DIFF
--- a/src/wmmgr.cc
+++ b/src/wmmgr.cc
@@ -1907,9 +1907,7 @@ void YWindowManager::manageClient(YFrameClient* client, bool mapClient) {
             posHeight += frame->titleYN();
         }
 
-        if (limitPosition &&
-            !(client->sizeHints() &&
-              (client->sizeHints()->flags & USPosition)))
+        if (limitPosition)
         {
             int mx, my, Mx, My;
             getWorkArea(frame, &mx, &my, &Mx, &My);


### PR DESCRIPTION
Some clients like Qt 6.10 sends a static position to the top left corner, which needs to be moved to fit the window frame to the screen.

See also: https://bugreports.qt.io/browse/QTBUG-141099