### PR TITLE
Define compatible version range to avoid warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...3.15)
 CMAKE_POLICY (SET CMP0053 NEW)
 PROJECT(ICEWM CXX)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...3.15)
 PROJECT(ICEWM CXX)
 
 #

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 # to use target_link_options
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.5...3.15)
 
 PROJECT(ICEWM CXX)
 


### PR DESCRIPTION
This uses the legal "...max" trick which works since version 3.12 while retaining compatibility with older versions.